### PR TITLE
ci: fix commitlint and run build on pull_request LS-1709

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -9,6 +9,6 @@ module.exports = {
       'always',
       ['all', 'deps', 'deps-dev', 'packages', 'release', 'root', ...readdirSync('./packages')],
     ],
-    'scope-empty': [2, 'never'],
+    'scope-empty': [1, 'never'],
   },
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: build
-on: push
+on: [push, pull_request]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Creates new package from template.
 
 Lints all packages.
 
+### `yarn lint:fix`
+
+Fixes lint errors for all packages.
+
 ### `yarn storybook`
 
 Runs Storybook.


### PR DESCRIPTION
## Jira

[Fix design-system build](https://littlespoon.atlassian.net/browse/LS-1709)

## Motivation

ci: fix commitlint and run build on pull_request

## Current Behavior

- commitlint fails when release-please PR is merged to master because `scope-empty` errors
- `build` workflow only runs on `push`

## New Behavior

- commitlint warns instead of errors for `scope-empty` rule
- `build` workflow also runs on `pull_request`

## Checklist

- [x] [Conventional Commits](https://www.conventionalcommits.org/)