### PR TITLE
ci: fix release-please LS-1713

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.actor != 'github-actions[bot]'
 
     steps:
       - name: Checkout repository

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "bootstrap-sha": "36884a5cb2739890df2f7a455b0cccec4b2c3d3c",
   "plugins": ["node-workspace"],
+  "always-link-local": true,
   "release-type": "node",
   "packages": {
     "packages/storybook": {},


### PR DESCRIPTION
## Jira

[Fix release-please in design-system](https://littlespoon.atlassian.net/browse/LS-1713)

## Motivation

ci: fix release-please

## Current Behavior

- Release PR is stuck waiting for expected `build` status check to pass. See https://github.com/googleapis/release-please/issues/922
- Dependent package versions are not bumped. See https://github.com/googleapis/release-please/issues/1032

## New Behavior

- Skip `build` workflow for release PR since GitHub status checks are not run by the bot.
- Going to set [`"always-link-local": true`](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#breaking-versions) to see if that fixes the issue

## Affected Areas

CI

## Risk Analysis

Release PR breaks

## Linked Issues

#12

## Checklist

- [x] [Conventional Commits](https://www.conventionalcommits.org/)