### PR TITLE
ci(root): don't bump private package version during publish LS-1714

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: contains(github.actor, 'github-actions') == 'false'
+    if: contains(github.actor, 'github-actions') == false
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,13 +57,13 @@ jobs:
         if: |
           github.ref == 'refs/heads/master'
           && contains(github.event.inputs.dry-run, 'y')
-        run: yarn lerna version --no-git-tag-version --no-push --yes --loglevel=verbose
+        run: yarn lerna version --no-git-tag-version --no-private --no-push --yes --loglevel=verbose
 
       - name: Publish canary
         if: |
           github.ref != 'refs/heads/master'
           && contains(github.event.inputs.dry-run, 'N')
-        run: yarn lerna publish --canary
+        run: yarn lerna publish --no-private --canary
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -72,7 +72,7 @@ jobs:
         if: |
           github.ref == 'refs/heads/master'
           && contains(github.event.inputs.dry-run, 'N')
-        run: yarn lerna publish
+        run: yarn lerna publish --no-private
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,13 @@
       "conventionalCommits": true,
       "createRelease": "github",
       "exact": true,
-      "ignoreChanges": ["**/*.md", "**/*.spec.*", "**/*.test.*"],
+      "ignoreChanges": [
+        "**/__fixtures__/**",
+        "**/__tests__/**",
+        "**/*.md",
+        "**/*.spec.*",
+        "**/*.test.*"
+      ],
       "message": "chore(release): publish",
       "yes": true
     }


### PR DESCRIPTION
## Jira

[Ignore private packages during design-system publish](https://littlespoon.atlassian.net/browse/LS-1714)

## Motivation

ci(root): don't bump private package version during publish

https://github.com/lerna/lerna/tree/main/commands/version#--no-private

## Current Behavior

When running lerna [publish](https://github.com/little-spoon-dev/design-system/runs/3613986653?check_suite_focus=true#step:14:18), it bumps versions for private packages:

```
Changes:
 - storybook: 1.1.0 => 1.2.0 (private)
 - template: 1.0.0-alpha => 1.0.0-alpha.0 (private)
 - @littlespoon/theme: 1.0.0 => 1.1.0
```

## New Behavior

No longer bump version for private packages when running lerna publish

## Test Plan

Manually trigger dry-run publish workflow and verify private packages aren't bumped