### PR TITLE
ci(root): pass lerna options to publish workflow LS-1716

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,10 @@ on:
         description: 'Dry run? (y/N)'
         required: true
         default: 'N'
+      lerna-options:
+        description: 'Lerna publish options'
+        required: false
+        default: 'from-package'
 
 jobs:
   publish:
@@ -23,8 +27,8 @@ jobs:
 
       - name: Configure Git user
         run: |
-          git config --global user.name "${{ github.actor }}"
-          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -72,7 +76,7 @@ jobs:
         if: |
           github.ref == 'refs/heads/master'
           && contains(github.event.inputs.dry-run, 'N')
-        run: yarn lerna publish
+        run: yarn lerna publish ${{ github.event.inputs.lerna-options }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Jira

[Fix lerna publish in design-system](https://littlespoon.atlassian.net/browse/LS-1716)

## Motivation

ci(root): pass lerna options to publish workflow

## Current Behavior

Getting errors when running [publish](https://github.com/little-spoon-dev/design-system/runs/3615206717?check_suite_focus=true#step:14:25) workflow:

```
lerna WARN gitPush remote: error: GH006: Protected branch update failed for refs/heads/master.        
lerna WARN gitPush remote: error: Required status check "build" is expected. At least 1 approving review is required by reviewers with write access.        
lerna WARN gitPush To https://github.com/little-spoon-dev/design-system
lerna WARN gitPush  ! [remote rejected] master -> master (protected branch hook declined)
lerna WARN gitPush  ! [remote rejected] @littlespoon/theme@1.1.0 -> @littlespoon/theme@1.1.0 (atomic transaction failed)
lerna WARN gitPush  ! [remote rejected] storybook@1.2.0 -> storybook@1.2.0 (atomic transaction failed)
lerna WARN gitPush error: failed to push some refs to 'https://github.com/little-spoon-dev/design-system'
```

## New Behavior

Set default option `from-package` so lerna does not commit or tag and publishes any local packages whose version does not exist in the npm registry. See https://github.com/lerna/lerna/issues/1957