### PR TITLE
ci(root): pass option `--no-verify-access` to lerna publish LS-1716

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,7 +67,7 @@ jobs:
         if: |
           github.ref != 'refs/heads/master'
           && contains(github.event.inputs.dry-run, 'N')
-        run: yarn lerna publish --canary
+        run: yarn lerna publish --canary --no-verify-access
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -76,7 +76,7 @@ jobs:
         if: |
           github.ref == 'refs/heads/master'
           && contains(github.event.inputs.dry-run, 'N')
-        run: yarn lerna publish ${{ github.event.inputs.lerna-options }}
+        run: yarn lerna publish --no-verify-access ${{ github.event.inputs.lerna-options }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Jira

[Fix lerna publish in design-system](https://littlespoon.atlassian.net/browse/LS-1716)

## Motivation

ci(root): pass option `--no-verify-access` to lerna publish

## Current Behavior

[lerna publish errors](https://github.com/little-spoon-dev/design-system/runs/3615413131?check_suite_focus=true#step:14:23):

```
lerna info Verifying npm credentials
lerna http fetch GET 403 https://registry.npmjs.org/-/npm/v1/user 158ms
403 Forbidden - GET https://registry.npmjs.org/-/npm/v1/user
lerna ERR! EWHOAMI Authentication error. Use `npm whoami` to troubleshoot.
```

See https://github.com/lerna/lerna/issues/2788

## New Behavior

Pass option [`--no-verify-access`](https://github.com/lerna/lerna/tree/main/commands/publish#--no-verify-access)