### PR TITLE
feat(theme): add shade tokens to theme LS-1726

### DIFF
--- a/packages/theme/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/theme/__tests__/__snapshots__/index.test.ts.snap
@@ -168,6 +168,8 @@ Object {
       "borderSuccess": "rgba(153,199,187,1)",
       "borderWarning": "rgba(252,208,168,1)",
       "brand": "rgba(44,213,196,1)",
+      "shadeBlack": "#000000",
+      "shadeWhite": "#FFFFFF",
       "subSurfaceCritical": "rgba(250,233,231,1)",
       "subSurfaceInformative": "rgba(233,239,249,1)",
       "subSurfaceSuccess": "rgba(230,241,238,1)",

--- a/packages/theme/src/colors/token.ts
+++ b/packages/theme/src/colors/token.ts
@@ -31,7 +31,7 @@ export const shadeWhite = '#FFFFFF'
  *
  * {@link https://zeroheight.com/3ddd0f892/p/028ae9-colors/t/13b601}
  */
-export const surfacePrimary = '#FFFFFF'
+export const surfacePrimary = shadeWhite
 export const surfaceSecondary = grey10()
 export const surfaceStrong = '#14625A'
 export const surfaceContrast = grey80()

--- a/packages/theme/src/colors/token.ts
+++ b/packages/theme/src/colors/token.ts
@@ -19,6 +19,14 @@ import { grey10, grey20, grey30, grey40, grey60, grey80 } from './secondary'
 export const brand = blue60()
 
 /**
+ * Shade
+ *
+ * {@link https://zeroheight.com/3ddd0f892/p/028ae9-colors/b/036155/t/492c47}
+ */
+export const shadeBlack = '#000000'
+export const shadeWhite = '#FFFFFF'
+
+/**
  * Surface
  *
  * {@link https://zeroheight.com/3ddd0f892/p/028ae9-colors/t/13b601}
@@ -56,6 +64,8 @@ export const borderWarning = warning20()
 
 export default {
   brand,
+  shadeBlack,
+  shadeWhite,
   surfacePrimary,
   surfaceSecondary,
   surfaceStrong,


### PR DESCRIPTION
## Jira

[Add black and white color tokens to @littlespoon/theme](https://littlespoon.atlassian.net/browse/LS-1726)

## Motivation

feat(theme): add shade tokens to theme

## Current Behavior

Black and white shade token colors not in theme

## New Behavior

Black and white shade token colors are in theme

## Checklist

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Storybook
