### PR TITLE
ci(root): fix release-please workflow LS-1727

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,7 +8,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
+      releases_created: ${{ steps.release.outputs.releases_created }}
 
     steps:
       - name: Release Please
@@ -16,12 +16,12 @@ jobs:
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          command: manifest-pr
+          command: manifest
 
   publish:
     needs: release-please
     runs-on: ubuntu-latest
-    if: ${{ needs.release-please.outputs.release_created }}
+    if: ${{ needs.release-please.outputs.releases_created }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,5 @@
 {
-  "bootstrap-sha": "36884a5cb2739890df2f7a455b0cccec4b2c3d3c",
   "plugins": ["node-workspace"],
-  "always-link-local": true,
   "release-type": "node",
   "packages": {
     "packages/storybook": {},


### PR DESCRIPTION
## Jira

[Fix release-please in design-system](https://littlespoon.atlassian.net/browse/LS-1727)

## Motivation

ci(root): fix release-please workflow

## Current Behavior

release-please-action fails to publish

## New Behavior

Replace `release_created` with `releases_created` for manifest releaser. See https://github.com/google-github-actions/release-please-action/issues/317

## Checklist

- [x] [Conventional Commits](https://www.conventionalcommits.org/)