### PR TITLE
chore(all): default noEmit to true in root tsconfig.json LS-1780

### DIFF
--- a/packages/button/tsconfig.json
+++ b/packages/button/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "../../tsconfig.root",
+  "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "lib"
+    "outDir": "lib",
+    "noEmit": false
   },
   "include": ["src"]
 }

--- a/packages/storybook/tsconfig.json
+++ b/packages/storybook/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "../../tsconfig.root",
+  "extends": "../../tsconfig",
   "include": ["src"]
 }

--- a/packages/theme/tsconfig.json
+++ b/packages/theme/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "../../tsconfig.root",
+  "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "lib"
+    "outDir": "lib",
+    "noEmit": false
   },
   "include": ["src"]
 }

--- a/scripts/template/tsconfig.json
+++ b/scripts/template/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "../../tsconfig.root",
+  "extends": "../../tsconfig",
   "compilerOptions": {
-    "outDir": "lib"
+    "outDir": "lib",
+    "noEmit": false
   },
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "declarationMap": true,
     "sourceMap": true,
     "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
     "strict": true,
     "skipLibCheck": true,
     "esModuleInterop": true


### PR DESCRIPTION
## Jira

[Refactor tsconfig.json in design-system](https://littlespoon.atlassian.net/browse/LS-1780)

## Motivation

chore(all): default noEmit to true in root tsconfig.json

## Current Behavior

`noEmit` is false in root `tsconfig.json`

## New Behavior

`noEmit` is true in root `tsconfig.json`. `noEmit` is set to false for package `tsconfig.json`.

The change allows `tsconfig.root.json` to be renamed to `tsconfig.json`, which allows IDE to pick up the config

## Checklist

- [x] [Conventional Commits](https://www.conventionalcommits.org/)