### PR TITLE
chore(all): specify only react 17 in peerDependencies LS-1801

### DIFF
--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -16,7 +16,7 @@
     "@littlespoon/theme": "1.3.0"
   },
   "peerDependencies": {
-    "react": "16 || 17",
+    "react": "17",
     "styled-components": "4 || 5"
   },
   "repository": {

--- a/templates/react-template/package.json
+++ b/templates/react-template/package.json
@@ -14,7 +14,7 @@
     "test:watch": "jest --watch"
   },
   "peerDependencies": {
-    "react": "16 || 17",
+    "react": "17",
     "styled-components": "4 || 5"
   },
   "repository": {


### PR DESCRIPTION
## Jira

[Specify react v17 in package peerDependencies in design-system](https://littlespoon.atlassian.net/browse/LS-1801)

## Motivation

Since JSX transform is not supported in versions below 17

## Current Behavior

`button` and `react-template` has react peerDependencies set to `16 || 17`

## New Behavior

`button` and `react-template` has react peerDependencies set to `17`

## Checklist

- [x] [Conventional Commits](https://www.conventionalcommits.org/)