### PR TITLE
ci(root): run lerna publish without workflow dispatch LS-1805

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Publish canary
         if: |
           github.ref != 'refs/heads/master'
-          && contains(github.event.inputs.dry-run, 'N')
+          && contains(github.event.inputs.dry-run, 'y') == false
         run: yarn lerna publish --canary --no-verify-access
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -77,7 +77,7 @@ jobs:
       - name: Publish
         if: |
           github.ref == 'refs/heads/master'
-          && contains(github.event.inputs.dry-run, 'N')
+          && contains(github.event.inputs.dry-run, 'y') == false
         run: yarn lerna publish --no-verify-access
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Related to #59

## Jira

[Switch release strategy from release-please to lerna for design-system](https://littlespoon.atlassian.net/browse/LS-1805)

## Motivation

Allow `publish` to be run on CI without triggering workflow dispatch

## Current Behavior

[publish](https://github.com/little-spoon-dev/design-system/runs/3691477909) is skipped on `master`

## New Behavior

Run `publish` on `master`

## Checklist

- [x] [Conventional Commits](https://www.conventionalcommits.org/)