### PR TITLE
feat: allow button to render as a different component LS-1777

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,6 +18,7 @@
   "ignorePatterns": ["lib"],
   "rules": {
     "@typescript-eslint/ban-ts-comment": "off",
+    "@typescript-eslint/no-extra-semi": "off",
     "@typescript-eslint/no-non-null-assertion": "off",
     "no-console": "error",
     "no-debugger": "error",

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -10,7 +10,6 @@
     - [`yarn lint`](#yarn-lint)
     - [`yarn lint:fix`](#yarn-lintfix)
     - [`yarn storybook`](#yarn-storybook)
-    - [`yarn sync-modules`](#yarn-sync-modules)
     - [`yarn test`](#yarn-test)
 - [Release](#release)
   - [Canary](#canary)

--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -39,3 +39,9 @@ Render button with props:
   Hello, world!
 </Button>
 ```
+
+Render button as a link:
+
+```tsx
+<Button as="a">This is a link</Button>
+```

--- a/packages/button/__tests__/Button.test.tsx
+++ b/packages/button/__tests__/Button.test.tsx
@@ -4,9 +4,11 @@ import { axe } from 'jest-axe'
 import type { ButtonProps } from '../src/'
 import Button from '../src/'
 
+const children = 'children'
+
 describe('accessibility', () => {
   it('is accessible with text', async () => {
-    const { container } = render(<Button>text</Button>)
+    const { container } = render(<Button>{children}</Button>)
     expect(await axe(container)).toHaveNoViolations()
   })
 
@@ -20,24 +22,24 @@ describe('no props', () => {
   it('renders button', () => {
     render(<Button />)
     // @ts-ignore
-    expect(screen.getByRole('button')).toBeInTheDocument()
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'button')
   })
 })
 
 describe('with props.children', () => {
   it('renders text', () => {
-    render(<Button>text</Button>)
+    render(<Button>{children}</Button>)
     // @ts-ignore
-    expect(screen.getByRole('button', { name: 'text' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: children })).toBeInTheDocument()
   })
 
   it('renders span with text', () => {
     render(
       <Button>
-        <span>text</span>
+        <span>{children}</span>
       </Button>,
     )
-    expect(screen.getByText('text')).toBeInTheDocument()
+    expect(screen.getByText(children)).toBeInTheDocument()
   })
 })
 
@@ -49,7 +51,7 @@ describe('with props.aria-label', () => {
 })
 
 describe('with props.size', () => {
-  it.each<ButtonProps['size']>(['small', 'medium', 'large', 'xlarge'])(
+  it.each<ButtonProps<'button'>['size']>(['small', 'medium', 'large', 'xlarge'])(
     'renders button with size=%j',
     (size) => {
       render(<Button size={size}>{size}</Button>)
@@ -59,27 +61,30 @@ describe('with props.size', () => {
 })
 
 describe('with props.variant', () => {
-  it.each<ButtonProps['variant']>(['primary', 'secondary', 'ghost', 'overlay', 'critical'])(
-    'renders button with variant=%j',
-    (variant) => {
-      render(<Button variant={variant}>{variant}</Button>)
-      expect(screen.getByText(variant!)).toBeInTheDocument()
-    },
-  )
+  it.each<ButtonProps<'button'>['variant']>([
+    'primary',
+    'secondary',
+    'ghost',
+    'overlay',
+    'critical',
+  ])('renders button with variant=%j', (variant) => {
+    render(<Button variant={variant}>{variant}</Button>)
+    expect(screen.getByText(variant!)).toBeInTheDocument()
+  })
 
   it('does not throw for invalid size', () => {
-    render(<Button size={'' as ButtonProps['size']}>text</Button>)
-    expect(screen.getByText('text')).toBeInTheDocument()
+    render(<Button size={'' as ButtonProps<'button'>['size']}>{children}</Button>)
+    expect(screen.getByText(children)).toBeInTheDocument()
   })
 })
 
 describe('with props.variant', () => {
   it('does not throw for invalid variant', () => {
-    render(<Button variant={'' as ButtonProps['variant']}>text</Button>)
-    expect(screen.getByText('text')).toBeInTheDocument()
+    render(<Button variant={'' as ButtonProps<'button'>['variant']}>{children}</Button>)
+    expect(screen.getByText(children)).toBeInTheDocument()
   })
 
-  it.each<ButtonProps['variant']>(['primary', 'secondary'])(
+  it.each<ButtonProps<'button'>['variant']>(['primary', 'secondary'])(
     'renders button with variant=%j',
     (variant) => {
       render(<Button variant={variant}>{variant}</Button>)
@@ -90,13 +95,12 @@ describe('with props.variant', () => {
 
 describe('with props.disabled', () => {
   it('renders disabled button not throw for invalid variant', () => {
-    const text = 'text'
     // @ts-ignore
-    render(<Button disabled>{text}</Button>)
-    expect(screen.getByText(text)).toBeDisabled()
+    render(<Button disabled>{children}</Button>)
+    expect(screen.getByText(children)).toBeDisabled()
   })
 
-  it.each<ButtonProps['variant']>(['primary', 'secondary'])(
+  it.each<ButtonProps<'button'>['variant']>(['primary', 'secondary'])(
     'renders disabled button with variant=%j',
     (variant) => {
       render(
@@ -108,4 +112,23 @@ describe('with props.disabled', () => {
       expect(screen.getByText(variant!)).toBeDisabled()
     },
   )
+})
+
+describe('with props.as', () => {
+  it('renders link', () => {
+    const href = 'https://example.com/'
+    render(
+      <Button as="a" href={href}>
+        {children}
+      </Button>,
+    )
+    // @ts-ignore
+    expect(screen.getByRole('link', { name: children })).toHaveAttribute('href', href)
+  })
+
+  it('renders component', () => {
+    const Component = () => <>{children}</>
+    render(<Button as={Component} />)
+    expect(screen.getByText(children)).toBeInTheDocument()
+  })
 })

--- a/packages/button/__tests__/Button.test.tsx
+++ b/packages/button/__tests__/Button.test.tsx
@@ -7,14 +7,32 @@ import Button from '../src/'
 const children = 'children'
 
 describe('accessibility', () => {
-  it('is accessible with text', async () => {
-    const { container } = render(<Button>{children}</Button>)
-    expect(await axe(container)).toHaveNoViolations()
+  describe('button', () => {
+    it('is accessible with text', async () => {
+      const { container } = render(<Button>{children}</Button>)
+      expect(await axe(container)).toHaveNoViolations()
+    })
+
+    it('is not accessible without text', async () => {
+      const { container } = render(<Button />)
+      expect(await axe(container)).not.toHaveNoViolations()
+    })
   })
 
-  it('is not accessible without text', async () => {
-    const { container } = render(<Button />)
-    expect(await axe(container)).not.toHaveNoViolations()
+  describe('link', () => {
+    it('is accessible with text and href', async () => {
+      const { container } = render(
+        <Button as="a" href="#">
+          {children}
+        </Button>,
+      )
+      expect(await axe(container)).toHaveNoViolations()
+    })
+
+    it('is not accessible without text and href', async () => {
+      const { container } = render(<Button as="a" href="" />)
+      expect(await axe(container)).not.toHaveNoViolations()
+    })
   })
 })
 

--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -2,7 +2,12 @@ import type React from 'react'
 
 import { ButtonBase } from './ButtonBase'
 
-export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface Props<C extends React.ElementType> {
+  /**
+   * The root node component. Use a string for an HTML element or a component. Defaults to "button".
+   */
+  as?: C
+
   /**
    * The content of the component.
    */
@@ -19,10 +24,17 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
   variant?: 'primary' | 'secondary' | 'ghost' | 'overlay' | 'critical'
 }
 
-export default function Button({
+export type ButtonProps<C extends React.ElementType> = Props<C> &
+  Omit<React.ComponentPropsWithoutRef<C>, keyof Props<C>>
+
+export default function Button<C extends React.ElementType = 'button'>({
   size = 'medium',
   variant = 'primary',
-  ...props
-}: ButtonProps): React.ReactElement<ButtonProps> {
-  return <ButtonBase type="button" {...props} size={size} variant={variant} />
+  ...other
+}: ButtonProps<C>): React.ReactElement<ButtonProps<C>> {
+  ;(other as ButtonProps<'button'>).as = other.as || 'button'
+  if (other.as === 'button' && !other.type) {
+    ;(other as ButtonProps<'button'>).type = other.as
+  }
+  return <ButtonBase {...other} size={size} variant={variant} />
 }

--- a/packages/button/src/ButtonBase.tsx
+++ b/packages/button/src/ButtonBase.tsx
@@ -10,7 +10,7 @@ import type { ButtonProps } from './Button'
 /**
  * Gets size styles.
  */
-function getSizeCss(props: ButtonProps): string {
+function getSizeCss(props: ButtonProps<'button'>): string {
   switch (props.size) {
     case 'small':
       return `
@@ -56,7 +56,7 @@ function getSizeCss(props: ButtonProps): string {
 /**
  * Gets variant styles.
  */
-function getVariantCss(props: ButtonProps): string {
+function getVariantCss(props: ButtonProps<'button'>): string {
   /**
    * {@link https://zeroheight.com/3ddd0f892/p/01a397-buttons/t/190120}
    */
@@ -122,12 +122,13 @@ function getVariantCss(props: ButtonProps): string {
   }
 }
 
-export const ButtonBase = styled.button<ButtonProps>`
+export const ButtonBase = styled.button<ButtonProps<'button'>>`
+  align-items: center;
   border: 0;
   border-radius: 0.5rem;
   box-sizing: border-box;
   cursor: pointer;
-  display: inline-block;
+  display: inline-flex;
   font: ${primary.weight.bold} 1.6rem ${primary.family};
   letter-spacing: 0.15rem;
   text-transform: uppercase;

--- a/packages/storybook/src/stories/Button.stories.tsx
+++ b/packages/storybook/src/stories/Button.stories.tsx
@@ -15,8 +15,8 @@ Default.args = {
 
 export const Primary = Template.bind({})
 Primary.args = {
+  as: 'button',
   children: 'primary',
-  component: 'button',
   disabled: false,
   size: 'medium',
   variant: 'primary',
@@ -24,8 +24,8 @@ Primary.args = {
 
 export const Secondary = Template.bind({})
 Secondary.args = {
+  as: 'button',
   children: 'secondary',
-  component: 'button',
   disabled: false,
   size: 'medium',
   variant: 'secondary',
@@ -33,8 +33,8 @@ Secondary.args = {
 
 export const Disabled = Template.bind({})
 Disabled.args = {
+  as: 'button',
   children: 'disabled',
-  component: 'button',
   disabled: true,
   size: 'medium',
   variant: 'primary',
@@ -42,8 +42,8 @@ Disabled.args = {
 
 export const Small = Template.bind({})
 Small.args = {
-  children: 'primary',
-  component: 'button',
+  as: 'button',
+  children: 'small',
   disabled: false,
   size: 'small',
   variant: 'primary',
@@ -51,8 +51,8 @@ Small.args = {
 
 export const Medium = Template.bind({})
 Medium.args = {
-  children: 'primary',
-  component: 'button',
+  as: 'button',
+  children: 'medium',
   disabled: false,
   size: 'medium',
   variant: 'primary',
@@ -60,8 +60,8 @@ Medium.args = {
 
 export const Large = Template.bind({})
 Large.args = {
-  children: 'primary',
-  component: 'button',
+  as: 'button',
+  children: 'large',
   disabled: false,
   size: 'large',
   variant: 'primary',
@@ -69,9 +69,25 @@ Large.args = {
 
 export const ExtraLarge = Template.bind({})
 ExtraLarge.args = {
-  children: 'primary',
-  component: 'button',
+  as: 'button',
+  children: 'xlarge',
   disabled: false,
   size: 'xlarge',
   variant: 'primary',
+}
+
+export const Link = Template.bind({})
+Link.args = {
+  as: 'a',
+  children: 'link',
+  disabled: false,
+  href: '#',
+  size: 'medium',
+  variant: 'primary',
+}
+
+export const Click = Template.bind({})
+Click.args = {
+  children: 'click',
+  onClick: () => alert('Clicked!'),
 }

--- a/packages/storybook/tsconfig.json
+++ b/packages/storybook/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig",
+  "compilerOptions": {
+    "lib": ["dom", "es5"]
+  },
   "include": ["src"]
 }


### PR DESCRIPTION
## Jira

[Allow button to be a link in design-system](https://littlespoon.atlassian.net/browse/LS-1777)

## Motivation

To render button links or a different element/component.

## Current Behavior

Button only renders as `button`.

## New Behavior

Button is polymorphic and can render as a different component:

```tsx
<Button as="a" />
<Button as={Route} />
```

## Checklist

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation
- [x] Storybook