### PR TITLE
ci: run auto-approve on pull_request_target in build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: build
 on:
   - push
-  - pull_request
+  - pull_request_target
 
 jobs:
   build:
@@ -81,7 +81,8 @@ jobs:
         run: yarn lerna run test --scope="${PACKAGE_NAME}*"
 
   auto-approve:
-    needs: build
+    if: github.event_name == 'pull_request_target'
+    needs: [build, scripts]
     runs-on: ubuntu-latest
     steps:
       - name: Auto Approve

--- a/lerna.json
+++ b/lerna.json
@@ -6,7 +6,7 @@
       "exact": true,
       "ignoreChanges": [
         "**/*.md",
-        "**/*.test.*",
+        "**/*.spec.*",
         "**/*.test.*",
         "**/*config*",
         "**/__fixtures__/**",


### PR DESCRIPTION
## Motivation

- ci: run auto-approve on `pull_request_target` in build
- chore: fix `lerna.json` ignoreChanges

## Current Behavior

- auto-approve runs on `push` in build
- `lerna.json` ignoreChanges has `test` twice

## New Behavior

- auto-approve runs on `pull_request_target` in build
- `lerna.json` ignoreChanges has `spec`

## Checklist

- [x] [Conventional Commits](https://www.conventionalcommits.org/)