### PR TITLE
feat(button): prevent button from inheriting parent width LS-1893

### DIFF
--- a/packages/button/src/ButtonBase.tsx
+++ b/packages/button/src/ButtonBase.tsx
@@ -130,6 +130,7 @@ export const ButtonBase = styled.button<ButtonProps<'button'>>`
   cursor: pointer;
   display: inline-flex;
   font: ${primary.weight.bold} 1.6rem ${primary.family};
+  width: fit-content;
   letter-spacing: 0.15rem;
   text-transform: uppercase;
   text-decoration: none;


### PR DESCRIPTION
<!--
Filling out the information below can facilitate the review/merge of the pull request (PR)
All fields are optional
-->

## Jira

https://littlespoon.atlassian.net/browse/LS-1893

## Motivation

Integrating new DS components to Order Modals

## Current Behavior

DS button inherits width from parent on mobile screens

<img width="547" alt="Screen Shot 2021-10-04 at 1 49 47 PM" src="https://user-images.githubusercontent.com/10041616/135899525-3570a25f-1b8f-4ac0-9791-3763768d9c42.png">

## New Behavior

DS button uses `fit-content` width

<img width="533" alt="Screen Shot 2021-10-04 at 1 52 57 PM" src="https://user-images.githubusercontent.com/10041616/135899948-892d77d8-0eb5-4273-ae76-04485a99c5ae.png">


<!-- If this is a feature change or bug fix -->

## Affected Areas

`@littlespoon/button`

## Risk Analysis

Browser support: https://developer.mozilla.org/en-US/docs/Web/CSS/fit-content#browser_compatibility