### PR TITLE
feat(breadcrumbs): rename prop `isActive` to `active` LS-2012

### DIFF
--- a/packages/breadcrumbs/__tests__/Breadcrumbs.test.tsx
+++ b/packages/breadcrumbs/__tests__/Breadcrumbs.test.tsx
@@ -1,4 +1,4 @@
-import { primary } from '@littlespoon/theme/lib/fonts'
+import { paragraph } from '@littlespoon/theme/lib/fonts/primary'
 import { render, screen } from '@testing-library/react'
 import { axe } from 'jest-axe'
 
@@ -6,70 +6,65 @@ import { Breadcrumbs } from '../src'
 import { Breadcrumb } from '../src'
 import type { BreadcrumbsProps } from '../src/'
 
-const componentsWithoutProps = (
+const url = 'https://example.com/'
+
+const breadcrumbs = (
   <Breadcrumbs>
     <Breadcrumb>
-      <a href={'url.com'}>Breadcrumb</a>
+      <a href={url}>Breadcrumb</a>
     </Breadcrumb>
     <Breadcrumb>
-      <a href={'url.com'}>Breadcrumb</a>
+      <a href={url}>Breadcrumb</a>
     </Breadcrumb>
-    <Breadcrumb isActive>Active</Breadcrumb>
+    <Breadcrumb active>Active</Breadcrumb>
   </Breadcrumbs>
 )
 
-const fontSizes = {
-  small: primary.paragraph.small.fontSize,
-  medium: primary.paragraph.medium.fontSize,
-  large: primary.paragraph.large.fontSize,
-}
-
-const sizes: ['small', 'medium', 'large'] = ['small', 'medium', 'large']
+const sizes = ['small', 'medium', 'large'] as const
 
 describe('accessibility', () => {
   it('is accessible when rendering Breadcrumbs', async () => {
-    const { container } = render(componentsWithoutProps)
+    const { container } = render(breadcrumbs)
     expect(await axe(container)).toHaveNoViolations()
   })
 })
 
-describe('rendering components', () => {
-  it('renders expected amount of breadcrumbs', () => {
-    render(componentsWithoutProps)
-    const breadcrumbs = screen.getAllByText('Breadcrumb')
-    expect(breadcrumbs).toHaveLength(2)
+describe('with props.children', () => {
+  it('renders expected number of breadcrumbs', () => {
+    render(breadcrumbs)
+    expect(screen.getAllByText('Breadcrumb')).toHaveLength(2)
     const active = screen.getAllByText('Active')
     expect(active).toHaveLength(1)
   })
 })
 
-describe('rendering sizes', () => {
+describe('with props.size', () => {
   it.each(sizes)('renders breadcrumbs with size=%j', (size) => {
     render(
       <Breadcrumbs size={size}>
         <Breadcrumb>
-          <a href={'url.com'}>Breadcrumb</a>
+          <a href={url}>Breadcrumb</a>
         </Breadcrumb>
         <Breadcrumb>
-          <a href={'url.com'}>Breadcrumb</a>
+          <a href={url}>Breadcrumb</a>
         </Breadcrumb>
-        <Breadcrumb isActive>Active</Breadcrumb>
+        <Breadcrumb active>Active</Breadcrumb>
       </Breadcrumbs>,
     )
     // @ts-ignore
-    expect(screen.getByRole('list')).toHaveStyle(`font-size: ${fontSizes[size]}`)
+    expect(screen.getByRole('list')).toHaveStyle(`font-size: ${paragraph[size].fontSize}`)
   })
 
   it('does not throw for invalid size', () => {
     render(
       <Breadcrumbs size={'' as BreadcrumbsProps['size']}>
         <Breadcrumb>
-          <a href={'url.com'}>Breadcrumb</a>
+          <a href={url}>Breadcrumb</a>
         </Breadcrumb>
         <Breadcrumb>
-          <a href={'url.com'}>Breadcrumb</a>
+          <a href={url}>Breadcrumb</a>
         </Breadcrumb>
-        <Breadcrumb isActive>Active</Breadcrumb>
+        <Breadcrumb active>Active</Breadcrumb>
       </Breadcrumbs>,
     )
     const breadcrumbs = screen.getAllByText('Breadcrumb')

--- a/packages/breadcrumbs/src/Breadcrumbs.tsx
+++ b/packages/breadcrumbs/src/Breadcrumbs.tsx
@@ -1,6 +1,12 @@
 import type React from 'react'
 
-import { ActiveBreadcrumb, BreadcrumbsList, BreadcrumbsWrapper, Crumb, Separator } from './styled'
+import {
+  BreadcrumbActive,
+  BreadcrumbItem,
+  BreadcrumbsList,
+  BreadcrumbsWrapper,
+  Separator,
+} from './styled'
 
 export interface BreadcrumbsProps extends React.HTMLAttributes<HTMLElement> {
   /**
@@ -11,12 +17,12 @@ export interface BreadcrumbsProps extends React.HTMLAttributes<HTMLElement> {
   children?: React.ReactNode
 }
 
-export const Breadcrumbs = ({
+export function Breadcrumbs({
   size = 'small',
   children,
-}: BreadcrumbsProps): React.ReactElement<BreadcrumbsProps> => {
+}: BreadcrumbsProps): React.ReactElement<BreadcrumbsProps> {
   return (
-    <BreadcrumbsWrapper aria-label="breadcrumbs">
+    <BreadcrumbsWrapper aria-label="breadcrumb">
       <BreadcrumbsList size={size}>{children}</BreadcrumbsList>
     </BreadcrumbsWrapper>
   )
@@ -26,24 +32,27 @@ export interface BreadcrumbProps {
   children?: React.ReactNode
 
   /**
-   * Determines if breadcrumb is active page
+   * Determines if breadcrumb is active. Defaults to false.
    */
-  isActive?: boolean
+  active?: boolean
 }
 
-export const Breadcrumb = ({
+export function Breadcrumb({
   children,
-  isActive = false,
-}: BreadcrumbProps): React.ReactElement<BreadcrumbProps> =>
-  isActive ? (
-    <ActiveBreadcrumb aria-current="page">{children}</ActiveBreadcrumb>
-  ) : (
+  active = false,
+}: BreadcrumbProps): React.ReactElement<BreadcrumbProps> {
+  if (active) {
+    return <BreadcrumbActive aria-current="page">{children}</BreadcrumbActive>
+  }
+
+  return (
     <>
-      <Crumb>{children}</Crumb>
+      <BreadcrumbItem>{children}</BreadcrumbItem>
       <Separator aria-hidden="true" role="separator">
         /
       </Separator>
     </>
   )
+}
 
 export default { Breadcrumbs, Breadcrumb }

--- a/packages/breadcrumbs/src/styled.tsx
+++ b/packages/breadcrumbs/src/styled.tsx
@@ -1,13 +1,13 @@
 import { informative50 } from '@littlespoon/theme/lib/colors/alert'
 import { visitedLinkPurple } from '@littlespoon/theme/lib/colors/secondary'
 import { shadeBlack } from '@littlespoon/theme/lib/colors/token'
-import { primary } from '@littlespoon/theme/lib/fonts'
+import { family, paragraph, weight } from '@littlespoon/theme/lib/fonts/primary'
 import styled from 'styled-components'
 
 import type { BreadcrumbsProps } from './Breadcrumbs'
 
 const defaultStyles = `
-  font-family: ${primary.family};
+  font-family: ${family};
   color: ${shadeBlack};
 `
 
@@ -18,20 +18,20 @@ function getSizeCss(props: BreadcrumbsProps): string {
   switch (props.size) {
     case 'small':
       return `
-        font-size: ${primary.paragraph.small.fontSize};
-        line-height: ${primary.paragraph.small.lineHeight};
+        font-size: ${paragraph.small.fontSize};
+        line-height: ${paragraph.small.lineHeight};
       `
 
     case 'medium':
       return `
-        font-size: ${primary.paragraph.medium.fontSize};
-        line-height: ${primary.paragraph.medium.lineHeight};
+        font-size: ${paragraph.medium.fontSize};
+        line-height: ${paragraph.medium.lineHeight};
       `
 
     case 'large':
       return `
-        font-size: ${primary.paragraph.large.fontSize};
-        line-height: ${primary.paragraph.large.lineHeight};
+        font-size: ${paragraph.large.fontSize};
+        line-height: ${paragraph.large.lineHeight};
       `
 
     default:
@@ -51,8 +51,8 @@ export const BreadcrumbsList = styled.ol`
   ${getSizeCss}
 `
 
-export const Crumb = styled.li`
-  > * {
+export const BreadcrumbItem = styled.li`
+  > a {
     ${defaultStyles}
     text-decoration: none;
 
@@ -60,19 +60,20 @@ export const Crumb = styled.li`
       outline: 0.2rem solid ${informative50()};
       outline-offset: 0.2rem;
     }
+
     &:visited {
       color: ${visitedLinkPurple()};
     }
   }
 `
 
-export const ActiveBreadcrumb = styled.li`
-  margin: 0;
+export const BreadcrumbActive = styled.li`
   ${defaultStyles}
-  font-weight: ${primary.weight.bold};
+  margin: 0;
+  font-weight: ${weight.bold};
 `
 
-export const Separator = styled.p`
-  margin: 0 1rem;
+export const Separator = styled.li`
   ${defaultStyles}
+  margin: 0 1rem;
 `

--- a/packages/storybook/src/stories/Breadcrumbs.stories.tsx
+++ b/packages/storybook/src/stories/Breadcrumbs.stories.tsx
@@ -4,49 +4,70 @@ import { ComponentMeta, ComponentStory } from '@storybook/react'
 export default {
   title: 'Design System/Breadcrumbs',
   component: Breadcrumbs,
-  subComponents: { Breadcrumb },
-  argTypes: {
-    size: {
-      options: ['small', 'medium', 'large'],
-      control: { type: 'radio' },
-    },
-  },
 } as ComponentMeta<typeof Breadcrumbs>
 
 const Template: ComponentStory<typeof Breadcrumbs> = (args) => <Breadcrumbs {...args} />
 
-export const NoBreadcrumbs = Template.bind({})
-NoBreadcrumbs.args = {}
+const url = 'https://example.com/'
 
-export const OneBreadcrumb = Template.bind({})
-OneBreadcrumb.args = {
-  children: <Breadcrumb isActive>Active</Breadcrumb>,
+export const Default = Template.bind({})
+Default.args = {
+  children: [
+    <Breadcrumb>
+      <a href={url}>Little</a>
+    </Breadcrumb>,
+    <Breadcrumb>
+      <a href={url}>Spoon</a>
+    </Breadcrumb>,
+    <Breadcrumb active>Breadcrumbs</Breadcrumb>,
+  ],
+}
+
+export const Empty = Template.bind({})
+Empty.args = {}
+
+export const Active = Template.bind({})
+Active.args = {
+  children: <Breadcrumb active>Active Breadcrumb</Breadcrumb>,
+}
+
+export const Two = Template.bind({})
+Two.args = {
+  children: [
+    <Breadcrumb>
+      <a href={url}>One</a>
+    </Breadcrumb>,
+    <Breadcrumb active>Two</Breadcrumb>,
+  ],
+}
+
+export const Three = Template.bind({})
+Three.args = {
+  children: [
+    <Breadcrumb>
+      <a href={url}>One</a>
+    </Breadcrumb>,
+    <Breadcrumb>
+      <a href={url}>Two</a>
+    </Breadcrumb>,
+    <Breadcrumb active>Three</Breadcrumb>,
+  ],
 }
 
 export const Small = Template.bind({})
 Small.args = {
+  children: [<Breadcrumb>Small</Breadcrumb>, <Breadcrumb active>Small Active</Breadcrumb>],
   size: 'small',
-  children: <Breadcrumb isActive>Active</Breadcrumb>,
 }
 
 export const Medium = Template.bind({})
 Medium.args = {
+  children: [<Breadcrumb>Medium</Breadcrumb>, <Breadcrumb active>Medium Active</Breadcrumb>],
   size: 'medium',
-  children: <Breadcrumb isActive>Active</Breadcrumb>,
 }
 
 export const Large = Template.bind({})
 Large.args = {
+  children: [<Breadcrumb>Large</Breadcrumb>, <Breadcrumb active>Large Active</Breadcrumb>],
   size: 'large',
-  children: <Breadcrumb isActive>Active</Breadcrumb>,
-}
-
-export const TwoBreadcrumbs = Template.bind({})
-TwoBreadcrumbs.args = {
-  children: [
-    <Breadcrumb>
-      <a href={window.location.href}>Breadcrumb</a>
-    </Breadcrumb>,
-    <Breadcrumb isActive>Active</Breadcrumb>,
-  ],
 }


### PR DESCRIPTION
Relates to #105

## Jira

[Improve Breadcrumbs in design-system](https://littlespoon.atlassian.net/browse/LS-2012)

## Motivation

feat(breadcrumbs): rename prop `isActive` to `active`

This is technically a BREAKING CHANGE but since it's not used anywhere yet, I'm going to make it a minor bump

## Current Behavior

- Breadcrumb has prop `isActive`
- Apply active styling to any descendent child

## New Behavior

- Breadcrumb has prop `active`
- Apply active styling only to descendent links
- Improve stories

## Checklist

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Storybook