### PR TITLE
feat(theme): export p1, p2, p3, p4 from fonts paragraph LS-2014

### DIFF
--- a/packages/theme/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/theme/__tests__/__snapshots__/index.test.ts.snap
@@ -223,6 +223,22 @@ Object {
           "fontSize": "1.6rem",
           "lineHeight": "2.4rem",
         },
+        "p1": Object {
+          "fontSize": "2rem",
+          "lineHeight": "3rem",
+        },
+        "p2": Object {
+          "fontSize": "1.8rem",
+          "lineHeight": "2.6rem",
+        },
+        "p3": Object {
+          "fontSize": "1.6rem",
+          "lineHeight": "2.4rem",
+        },
+        "p4": Object {
+          "fontSize": "1.4rem",
+          "lineHeight": "2rem",
+        },
         "small": Object {
           "fontSize": "1.4rem",
           "lineHeight": "2rem",

--- a/packages/theme/src/fonts/paragraph.ts
+++ b/packages/theme/src/fonts/paragraph.ts
@@ -5,44 +5,56 @@ import { rem } from '../utils'
  *
  * {@link https://zeroheight.com/3ddd0f892/p/211297-typography/t/9540b4}
  */
-export const xlarge = {
+export const p1 = {
   fontSize: rem(2),
   lineHeight: rem(3),
 } as const
+
+export const xlarge = p1
 
 /**
  * Paragraph 2
  *
  * {@link https://zeroheight.com/3ddd0f892/p/211297-typography/t/41a82b}
  */
-export const large = {
+export const p2 = {
   fontSize: rem(1.8),
   lineHeight: rem(2.6),
 } as const
+
+export const large = p2
 
 /**
  * Paragraph 3
  *
  * {@link https://zeroheight.com/3ddd0f892/p/211297-typography/t/48491c}
  */
-export const medium = {
+export const p3 = {
   fontSize: rem(1.6),
   lineHeight: rem(2.4),
 } as const
+
+export const medium = p3
 
 /**
  * Paragraph 4
  *
  * {@link https://zeroheight.com/3ddd0f892/p/211297-typography/t/7711fe}
  */
-export const small = {
+export const p4 = {
   fontSize: rem(1.4),
   lineHeight: rem(2),
 } as const
 
+export const small = p4
+
 export default {
+  p1,
   xlarge,
+  p2,
   large,
+  p3,
   medium,
+  p4,
   small,
 }

--- a/packages/ui/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/ui/__tests__/__snapshots__/index.test.ts.snap
@@ -228,6 +228,22 @@ Object {
             "fontSize": "1.6rem",
             "lineHeight": "2.4rem",
           },
+          "p1": Object {
+            "fontSize": "2rem",
+            "lineHeight": "3rem",
+          },
+          "p2": Object {
+            "fontSize": "1.8rem",
+            "lineHeight": "2.6rem",
+          },
+          "p3": Object {
+            "fontSize": "1.6rem",
+            "lineHeight": "2.4rem",
+          },
+          "p4": Object {
+            "fontSize": "1.4rem",
+            "lineHeight": "2rem",
+          },
           "small": Object {
             "fontSize": "1.4rem",
             "lineHeight": "2rem",


### PR DESCRIPTION
## Jira

[Export theme fonts p1, p2, p3, p4 in design-system](https://littlespoon.atlassian.net/browse/LS-2014)

## Motivation

feat(theme): export p1, p2, p3, p4 from fonts paragraph

This is because we have 4 different paragraph styles: https://zeroheight.com/3ddd0f892/p/211297-typography/t/294b11

## Checklist

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests