### PR TITLE
fix(tag): add icons to dependencies and fix import path

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,18 +14,13 @@
     "ecmaVersion": 12,
     "sourceType": "module"
   },
-  "plugins": [
-    "@typescript-eslint",
-    "eslint-plugin-tsdoc",
-    "jsx-a11y",
-    "prettier",
-    "simple-import-sort"
-  ],
+  "plugins": ["@typescript-eslint", "jsx-a11y", "prettier", "simple-import-sort", "tsdoc"],
   "ignorePatterns": ["lib"],
   "rules": {
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/no-extra-semi": "off",
     "@typescript-eslint/no-non-null-assertion": "off",
+    "@typescript-eslint/no-unused-vars": "error",
     "no-console": "error",
     "no-debugger": "error",
     "prettier/prettier": "error",

--- a/packages/tag/__tests__/Tag.test.tsx
+++ b/packages/tag/__tests__/Tag.test.tsx
@@ -1,7 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { axe } from 'jest-axe'
 
-import CloseIcon from '../../icons/src/CloseIcon'
 import type { TagProps } from '../src'
 import Tag from '../src'
 

--- a/packages/tag/package.json
+++ b/packages/tag/package.json
@@ -13,6 +13,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
+    "@littlespoon/icons": "1.5.1",
     "@littlespoon/theme": "1.9.0"
   },
   "peerDependencies": {

--- a/packages/tag/src/Tag.tsx
+++ b/packages/tag/src/Tag.tsx
@@ -1,4 +1,4 @@
-import CloseIcon from '@littlespoon/icons/src/CloseIcon'
+import CloseIcon from '@littlespoon/icons/lib/CloseIcon'
 import type React from 'react'
 
 import { Button, DefaultTag, DeletableTag, VisuallyHidden } from './styled'

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,6 +18,7 @@
     "@littlespoon/checkbox": "1.1.1",
     "@littlespoon/divider": "1.1.1",
     "@littlespoon/icons": "1.5.1",
+    "@littlespoon/tag": "1.1.1",
     "@littlespoon/theme": "1.9.0",
     "@littlespoon/typography": "1.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3892,14 +3892,6 @@
     "@typescript-eslint/typescript-estree" "5.2.0"
     debug "^4.3.2"
 
-"@typescript-eslint/scope-manager@5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.1.0.tgz#6f1f26ad66a8f71bbb33b635e74fec43f76b44df"
-  integrity sha512-yYlyVjvn5lvwCL37i4hPsa1s0ORsjkauhTqbb8MnpvUs7xykmcjGqwlNZ2Q5QpoqkJ1odlM2bqHqJwa28qV6Tw==
-  dependencies:
-    "@typescript-eslint/types" "5.1.0"
-    "@typescript-eslint/visitor-keys" "5.1.0"
-
 "@typescript-eslint/scope-manager@5.2.0":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.2.0.tgz#7ce8e4ab2baaa0ad5282913ea8e13ce03ec6a12a"
@@ -3908,28 +3900,10 @@
     "@typescript-eslint/types" "5.2.0"
     "@typescript-eslint/visitor-keys" "5.2.0"
 
-"@typescript-eslint/types@5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.1.0.tgz#a8a75ddfc611660de6be17d3ad950302385607a9"
-  integrity sha512-sEwNINVxcB4ZgC6Fe6rUyMlvsB2jvVdgxjZEjQUQVlaSPMNamDOwO6/TB98kFt4sYYfNhdhTPBEQqNQZjMMswA==
-
 "@typescript-eslint/types@5.2.0":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.2.0.tgz#7ad32d15abddb0ee968a330f0ea182ea544ef7cf"
   integrity sha512-cTk6x08qqosps6sPyP2j7NxyFPlCNsJwSDasqPNjEQ8JMD5xxj2NHxcLin5AJQ8pAVwpQ8BMI3bTxR0zxmK9qQ==
-
-"@typescript-eslint/typescript-estree@5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.1.0.tgz#132aea34372df09decda961cb42457433aa6e83d"
-  integrity sha512-SSz+l9YrIIsW4s0ZqaEfnjl156XQ4VRmJsbA0ZE1XkXrD3cRpzuZSVCyqeCMR3EBjF27IisWakbBDGhGNIOvfQ==
-  dependencies:
-    "@typescript-eslint/types" "5.1.0"
-    "@typescript-eslint/visitor-keys" "5.1.0"
-    debug "^4.3.2"
-    globby "^11.0.4"
-    is-glob "^4.0.3"
-    semver "^7.3.5"
-    tsutils "^3.21.0"
 
 "@typescript-eslint/typescript-estree@5.2.0":
   version "5.2.0"
@@ -3943,14 +3917,6 @@
     is-glob "^4.0.3"
     semver "^7.3.5"
     tsutils "^3.21.0"
-
-"@typescript-eslint/visitor-keys@5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.1.0.tgz#e01a01b27eb173092705ae983aa1451bd1842630"
-  integrity sha512-uqNXepKBg81JVwjuqAxYrXa1Ql/YDzM+8g/pS+TCPxba0wZttl8m5DkrasbfnmJGHs4lQ2jTbcZ5azGhI7kK+w==
-  dependencies:
-    "@typescript-eslint/types" "5.1.0"
-    eslint-visitor-keys "^3.0.0"
 
 "@typescript-eslint/visitor-keys@5.2.0":
   version "5.2.0"


### PR DESCRIPTION
## Motivation

fix(tag): add icons to dependencies and fix import path

## Current Behavior

- Tag is importing from `src` instead of `lib`
- Tag is missing `@littlespoon/icons` as a dependency
- `tag` is not a dependency in `ui`

## New Behavior

- Tag imports from `lib`
- Added `@littlespoon/icons` as a dependency to tag
- Added `@littlespoon/tag` as a dependency to ui

## Checklist

- [x] [Conventional Commits](https://www.conventionalcommits.org/)