### PR TITLE
feat(button): add variant `tertiary` LS-2152

### DIFF
--- a/packages/button/__tests__/Button.test.tsx
+++ b/packages/button/__tests__/Button.test.tsx
@@ -5,6 +5,7 @@ import type { ButtonProps } from '../src/'
 import Button from '../src/'
 
 const children = 'children'
+const variants = ['primary', 'secondary', 'tertiary', 'ghost'] as const
 
 describe('accessibility', () => {
   describe('button', () => {
@@ -43,7 +44,6 @@ describe('accessibility', () => {
 describe('no props', () => {
   it('renders button', () => {
     render(<Button />)
-    // @ts-ignore
     expect(screen.getByRole('button')).toHaveAttribute('type', 'button')
   })
 })
@@ -51,7 +51,6 @@ describe('no props', () => {
 describe('with props.children', () => {
   it('renders text', () => {
     render(<Button>{children}</Button>)
-    // @ts-ignore
     expect(screen.getByRole('button', { name: children })).toBeInTheDocument()
   })
 
@@ -83,22 +82,19 @@ describe('with props.size', () => {
 })
 
 describe('with props.variant', () => {
-  it.each<Required<ButtonProps<'button'>>['variant']>([
-    'primary',
-    'secondary',
-    'ghost',
-    'overlay',
-    'critical',
-  ])('renders button with variant=%j', (variant) => {
-    render(<Button variant={variant}>{variant}</Button>)
-    expect(screen.getByText(variant)).toBeInTheDocument()
-  })
+  it.each<Required<ButtonProps<'button'>>['variant']>(variants)(
+    'renders button with variant=%j',
+    (variant) => {
+      render(<Button variant={variant}>{variant}</Button>)
+      expect(screen.getByText(variant)).toBeInTheDocument()
+    },
+  )
 
   it.each<[Required<ButtonProps<'button'>>['variant'], string]>([
     ['primary', 'background-color: rgb(0, 0, 0)'],
     ['secondary', 'background-color: rgb(0, 227, 205)'],
+    ['tertiary', 'background-color: rgb(255, 255, 255)'],
     ['ghost', 'background-color: rgb(255, 255, 255)'],
-    ['critical', 'background-color: ButtonFace'],
   ])('renders button with %s style', (variant, style) => {
     render(<Button variant={variant}>{variant}</Button>)
     expect(document.querySelectorAll('button')).toHaveLength(1)
@@ -117,7 +113,7 @@ describe('with props.variant', () => {
     expect(screen.getByText(children)).toBeInTheDocument()
   })
 
-  it.each<Required<ButtonProps<'button'>>['variant']>(['primary', 'secondary'])(
+  it.each<Required<ButtonProps<'button'>>['variant']>(variants)(
     'renders button with variant=%j',
     (variant) => {
       render(<Button variant={variant}>{variant}</Button>)
@@ -132,7 +128,7 @@ describe('with props.disabled', () => {
     expect(screen.getByText(children)).toBeDisabled()
   })
 
-  it.each<Required<ButtonProps<'button'>>['variant']>(['primary', 'secondary'])(
+  it.each<Required<ButtonProps<'button'>>['variant']>(variants)(
     'renders disabled button with variant=%j',
     (variant) => {
       render(
@@ -153,7 +149,6 @@ describe('with props.as', () => {
         {children}
       </Button>,
     )
-    // @ts-ignore
     const element = screen.getByRole('link', { name: children })
     expect(element).toHaveAttribute('href', href)
     expect(element).toHaveStyle('color: rgb(255, 255, 255)')

--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -21,7 +21,7 @@ export interface Props<C extends React.ElementType> {
   /**
    * The variant to use. Defaults to "primary".
    */
-  variant?: 'primary' | 'secondary' | 'ghost' | 'overlay' | 'critical'
+  variant?: 'primary' | 'secondary' | 'tertiary' | 'ghost'
 }
 
 export type ButtonProps<C extends React.ElementType> = Props<C> &

--- a/packages/button/src/ButtonBase.tsx
+++ b/packages/button/src/ButtonBase.tsx
@@ -180,5 +180,9 @@ function getVariantCss(props: ButtonProps<'button'>): string {
     &:visited {
       color: ${color};
     }
+    // remove focus styles for non-keyboard focus
+    :focus:not(:focus-visible) {
+      outline: 0;
+    }
   `
 }

--- a/packages/button/src/ButtonBase.tsx
+++ b/packages/button/src/ButtonBase.tsx
@@ -1,6 +1,6 @@
 import { informative50 } from '@littlespoon/theme/lib/colors/alert'
 import { blue30, blue60, blue80 } from '@littlespoon/theme/lib/colors/primary'
-import { grey20, grey40, grey70, grey80 } from '@littlespoon/theme/lib/colors/secondary'
+import { grey10, grey20, grey40, grey70, grey80 } from '@littlespoon/theme/lib/colors/secondary'
 import { shadeBlack, shadeWhite } from '@littlespoon/theme/lib/colors/token'
 import { button, family, weight } from '@littlespoon/theme/lib/fonts/primary'
 import { rem } from '@littlespoon/theme/lib/utils'
@@ -125,6 +125,20 @@ function getVariantCss(props: ButtonProps<'button'>): string {
         hoverBackgroundColor = blue30()
         hoverColor = color
         activeBackgroundColor = blue80()
+        activeColor = color
+        break
+
+      /**
+       * {@link https://zeroheight.com/3ddd0f892/p/01a397-buttons/t/52ebb4}
+       */
+      case 'tertiary':
+        backgroundColor = shadeWhite
+        color = shadeBlack
+        focusColor = color
+        focusOutline = `${rem(0.2)} solid ${informative50()}`
+        hoverBackgroundColor = grey10()
+        hoverColor = shadeBlack
+        activeBackgroundColor = grey20()
         activeColor = color
         break
 

--- a/packages/storybook/src/stories/Button.stories.tsx
+++ b/packages/storybook/src/stories/Button.stories.tsx
@@ -25,6 +25,12 @@ Secondary.args = {
   variant: 'secondary',
 }
 
+export const Tertiary = Template.bind({})
+Tertiary.args = {
+  children: 'tertiary',
+  variant: 'tertiary',
+}
+
 export const Ghost = Template.bind({})
 Ghost.args = {
   children: 'ghost',


### PR DESCRIPTION
## Jira

[Add "tertiary" variant to Button in design-system](https://littlespoon.atlassian.net/browse/LS-2152)

## Motivation

- feat(button): add variant `tertiary`
- fix(button): remove focus styles for non-keyboard focus

## Current Behavior

- Button does not have variant `tertiary` ([ZeroHeight](https://zeroheight.com/3ddd0f892/p/01a397-buttons/t/52ebb4))
- Button has focus styles when mouse is used (we only want focus styles for keyboard use)

## New Behavior

- Button has variant `tertiary` ([ZeroHeight](https://zeroheight.com/3ddd0f892/p/01a397-buttons/t/52ebb4))
- Button only has focus styles for keyboard and not mouse

## Checklist

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Storybook