### PR TITLE
feat(tag): add padding between text and icon LS-2201

### DIFF
--- a/packages/tag/src/styled.tsx
+++ b/packages/tag/src/styled.tsx
@@ -61,6 +61,7 @@ export const DeletableTag = styled.div<TagProps>`
   ${getSizeCss}
   font-family: ${primary.family};
   display: inline-flex;
+  justify-content: space-between;
   align-items: center;
   padding: 0.6rem 0.6rem;
   background-color: ${secondary.secondaryNeutralGrey.grey100()};
@@ -70,8 +71,7 @@ export const DeletableTag = styled.div<TagProps>`
 
 export const Button = styled.button`
   background-color: ${secondary.secondaryNeutralGrey.grey100()};
-  padding-right: 0.2rem;
-  padding-top: 0.2rem;
+  padding: 0.2rem 0.2rem 0 0.8rem;
   border: none;
 `
 


### PR DESCRIPTION
<!--
Filling out the information below can facilitate the review/merge of the pull request (PR)
All fields are optional
-->

## Jira

[Add padding to CloseIcon in Tag Deletable state](https://littlespoon.atlassian.net/browse/LS-2201)

## Motivation

Using this package revealed that the text and icon were adjoined

## Current Behavior

Text and icon are adjoined

## New Behavior

There is space between the text and icon