### PR TITLE
fix(alert): fix import of theme colors

### DIFF
--- a/packages/alert/src/AlertBase.tsx
+++ b/packages/alert/src/AlertBase.tsx
@@ -1,9 +1,9 @@
 import Button from '@littlespoon/button'
 import Link from '@littlespoon/link'
+import colors from '@littlespoon/theme/lib/colors'
 import { p3, p4 } from '@littlespoon/theme/lib/fonts/paragraph'
 import { family, weight } from '@littlespoon/theme/lib/fonts/primary'
 import { rem } from '@littlespoon/theme/lib/utils'
-import colors from '@littlespoon/theme/src/colors'
 import styled from 'styled-components'
 
 import type { AlertProps } from './Alert'


### PR DESCRIPTION
Error:

```
Cannot find module '@littlespoon/theme/src/colors' from 'node_modules/@littlespoon/alert/lib/AlertBase.js'
```