### PR TITLE
fix(icons): add exports of new PCH icons LS-3975

### DIFF
--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -24,23 +24,40 @@ Import icons:
 
 ```tsx
 import icons from '@littlespoon/icons'
+icons.AccountIcon
+icons.AddIcon
 icons.ArrowIcon
+icons.BillIcon
+icons.BoxIcon
+icons.CalendarIcon
+icons.CaretIcon
+icons.CartIcon
 icons.CheckIcon
 icons.CloseIcon
 icons.ExclamationIcon
 icons.FilterIcon
-icons.AddIcon
+icons.GiftCardIcon
+icons.LogoutIcon
 icons.SubtractIcon
 ```
 
 Import icons:
 
 ```tsx
+import AccountIcon from '@littlespoon/ui/icons/AccountIcon'
+import AddIcon from '@littlespoon/ui/icons/AddIcon'
 import ArrowIcon from '@littlespoon/ui/icons/ArrowIcon'
+import BillIcon from '@littlespoon/ui/icons/BillIcon'
+import BoxIcon from '@littlespoon/ui/icons/BoxIcon'
+import CalendarIcon from '@littlespoon/ui/icons/CalendarIcon'
+import CaretIcon from '@littlespoon/ui/icons/CaretIcon'
+import CartIcon from '@littlespoon/ui/icons/CartIcon'
 import CheckIcon from '@littlespoon/ui/icons/CheckIcon'
 import CloseIcon from '@littlespoon/ui/icons/CloseIcon'
 import ExclamationIcon from '@littlespoon/ui/icons/ExclamationIcon'
-import FilterIcoon from '@littlespoon/ui/icons/FilterIcon'
-import AddIcon from '@littlespoon/ui/icons/AddIcon'
+import FilterIcon from '@littlespoon/ui/icons/FilterIcon'
+import GiftCardIcon from '@littlespoon/ui/icons/GiftCardIcon'
+import HamburgerMenuIcon from '@littlespoon/ui/icons/HamburgerMenuIcon'
+import LogoutIcon from '@littlespoon/ui/icons/LogoutIcon'
 import SubtractIcon from '@littlespoon/ui/icons/SubtractIcon'
 ```

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -1,17 +1,53 @@
+import AccountIcon from './AccountIcon'
+import AddIcon from './AddIcon'
 import ArrowIcon from './ArrowIcon'
+import BillIcon from './BillIcon'
+import BoxIcon from './BoxIcon'
+import CalendarIcon from './CalendarIcon'
+import CaretIcon from './CaretIcon'
+import CartIcon from './CartIcon'
 import CheckIcon from './CheckIcon'
 import CloseIcon from './CloseIcon'
 import ExclamationIcon from './ExclamationIcon'
 import FilterIcon from './FilterIcon'
+import GiftCardIcon from './GiftCardIcon'
+import HamburgerMenuIcon from './HamburgerMenuIcon'
+import LogoutIcon from './LogoutIcon'
 import SubtractIcon from './SubtractIcon'
 
-export { ArrowIcon, CheckIcon, CloseIcon, ExclamationIcon, FilterIcon, SubtractIcon }
+export {
+  AccountIcon,
+  AddIcon,
+  ArrowIcon,
+  BillIcon,
+  BoxIcon,
+  CalendarIcon,
+  CaretIcon,
+  CartIcon,
+  CheckIcon,
+  CloseIcon,
+  ExclamationIcon,
+  FilterIcon,
+  GiftCardIcon,
+  HamburgerMenuIcon,
+  LogoutIcon,
+  SubtractIcon,
+}
 
 export default {
+  AccountIcon,
+  AddIcon,
   ArrowIcon,
+  BillIcon,
+  BoxIcon,
   CloseIcon,
+  CalendarIcon,
+  CartIcon,
   FilterIcon,
   CheckIcon,
   ExclamationIcon,
+  GiftCardIcon,
+  HamburgerMenuIcon,
+  LogoutIcon,
   SubtractIcon,
 }

--- a/packages/ui/icons/AccountIcon/index.ts
+++ b/packages/ui/icons/AccountIcon/index.ts
@@ -1,0 +1,2 @@
+export { default } from '@littlespoon/icons/lib/AccountIcon'
+export * from '@littlespoon/icons/lib/AccountIcon'

--- a/packages/ui/icons/BillIcon/index.ts
+++ b/packages/ui/icons/BillIcon/index.ts
@@ -1,0 +1,2 @@
+export { default } from '@littlespoon/icons/lib/BillIcon'
+export * from '@littlespoon/icons/lib/BillIcon'

--- a/packages/ui/icons/BoxIcon/index.ts
+++ b/packages/ui/icons/BoxIcon/index.ts
@@ -1,0 +1,2 @@
+export { default } from '@littlespoon/icons/lib/BoxIcon'
+export * from '@littlespoon/icons/lib/BoxIcon'

--- a/packages/ui/icons/CalendarIcon/index.ts
+++ b/packages/ui/icons/CalendarIcon/index.ts
@@ -1,0 +1,2 @@
+export { default } from '@littlespoon/icons/lib/CalendarIcon'
+export * from '@littlespoon/icons/lib/CalendarIcon'

--- a/packages/ui/icons/CaretIcon/index.ts
+++ b/packages/ui/icons/CaretIcon/index.ts
@@ -1,0 +1,2 @@
+export { default } from '@littlespoon/icons/lib/CaretIcon'
+export * from '@littlespoon/icons/lib/CaretIcon'

--- a/packages/ui/icons/CartIcon/index.ts
+++ b/packages/ui/icons/CartIcon/index.ts
@@ -1,0 +1,2 @@
+export { default } from '@littlespoon/icons/lib/CartIcon'
+export * from '@littlespoon/icons/lib/CartIcon'

--- a/packages/ui/icons/CheckIcon/index.ts
+++ b/packages/ui/icons/CheckIcon/index.ts
@@ -1,0 +1,2 @@
+export { default } from '@littlespoon/icons/lib/CheckIcon'
+export * from '@littlespoon/icons/lib/CheckIcon'

--- a/packages/ui/icons/ExclamationIcon/index.ts
+++ b/packages/ui/icons/ExclamationIcon/index.ts
@@ -1,0 +1,2 @@
+export { default } from '@littlespoon/icons/lib/ExclamationIcon'
+export * from '@littlespoon/icons/lib/ExclamationIcon'

--- a/packages/ui/icons/GiftCardIcon/index.ts
+++ b/packages/ui/icons/GiftCardIcon/index.ts
@@ -1,0 +1,2 @@
+export { default } from '@littlespoon/icons/lib/GiftCardIcon'
+export * from '@littlespoon/icons/lib/GiftCardIcon'

--- a/packages/ui/icons/HamburgerMenuIcon/index.ts
+++ b/packages/ui/icons/HamburgerMenuIcon/index.ts
@@ -1,0 +1,2 @@
+export { default } from '@littlespoon/icons/lib/HamburgerMenuIcon'
+export * from '@littlespoon/icons/lib/HamburgerMenuIcon'

--- a/packages/ui/icons/LogoutIcon/index.ts
+++ b/packages/ui/icons/LogoutIcon/index.ts
@@ -1,0 +1,2 @@
+export { default } from '@littlespoon/icons/lib/LogoutIcon'
+export * from '@littlespoon/icons/lib/LogoutIcon'

--- a/packages/ui/icons/SubtractIcon/index.ts
+++ b/packages/ui/icons/SubtractIcon/index.ts
@@ -1,0 +1,2 @@
+export { default } from '@littlespoon/icons/lib/SubtractIcon'
+export * from '@littlespoon/icons/lib/SubtractIcon'


### PR DESCRIPTION
## Jira

[https://littlespoon.atlassian.net/browse/LS-3975](https://littlespoon.atlassian.net/browse/LS-3975)

## Motivation

Imports of new icons, like CalendarIcon are not working on the frontend

## Test Plan

Check whether new icons can be properly imported on the frontend

## Risk Analysis

Low risk, only added new imports