### PR TITLE
fix(icons): update add icon

### DIFF
--- a/packages/icons/__tests__/AddIcon.test.tsx
+++ b/packages/icons/__tests__/AddIcon.test.tsx
@@ -23,9 +23,7 @@ describe('with props.size', () => {
     'renders bill icon with size=%j',
     (size) => {
       render(<AddIcon aria-label={label} size={size} />)
-      expect(screen.getByLabelText(label)).toHaveStyle(
-        `transform: rotate(45deg) scale(${getScale(size)})`,
-      )
+      expect(screen.getByLabelText(label)).toHaveStyle(`transform: scale(${getScale(size)})`)
     },
   )
 

--- a/packages/icons/src/AddIcon.tsx
+++ b/packages/icons/src/AddIcon.tsx
@@ -39,7 +39,7 @@ export default function AddIcon({
       <circle cx="12" cy="12" r="12" fill={fill} />
       <title>Add icon</title>
       <path
-        d="m7.566 7.566 8.868 8.868m-8.868 0 8.868-8.868"
+        d="M12 2.75v18.5M2.75 12h18.5"
         stroke={stroke}
         strokeWidth="1.5"
         strokeLinecap="round"
@@ -54,5 +54,5 @@ const AddIconBase = styled.svg<AddIconProps>`
   justify-content: center;
   align-items: center;
   transition: transform 0.4s;
-  transform: rotate(45deg) scale(${(props) => getScale(props.size)});
+  transform: scale(${(props) => getScale(props.size)});
 `


### PR DESCRIPTION
Update add icon svg as @chantaldegaust provided.

The old icon was created by rotating close icon 45 degrees but the size was different from subtract icon.