### PR TITLE
chore(alert): adjust width for relative positioned alert - LS-3944

### DIFF
--- a/packages/alert/README.md
+++ b/packages/alert/README.md
@@ -35,3 +35,15 @@ Render alert with props:
 ```tsx
 <Alert title="Alert Title" description="Alert description" onClose={onClose} variant="success" />
 ```
+
+Render alert with relative position:
+
+```tsx
+<Alert
+  type="relative"
+  title="Alert Title"
+  description="Alert description"
+  onClose={onClose}
+  variant="success"
+/>
+```

--- a/packages/alert/src/AlertBase.tsx
+++ b/packages/alert/src/AlertBase.tsx
@@ -15,7 +15,7 @@ export const AlertWrapper = styled.div<Partial<AlertProps>>`
   border: 0;
   box-sizing: border-box;
   padding: 8px;
-  max-width: 800px;
+  max-width: ${(props) => (props.type === 'relative' ? '100%' : '800px')};
   width: 100%;
   color: ${colors.shadeBlack};
   ${(props) => (props.type === 'banner' ? `top: 0px` : 'bottom: 0px')};

--- a/packages/alert/src/AlertBase.tsx
+++ b/packages/alert/src/AlertBase.tsx
@@ -11,11 +11,11 @@ import type { AlertProps } from './Alert'
 export const AlertWrapper = styled.div<Partial<AlertProps>>`
   display: flex;
   position: ${(props) => (props.type === 'relative' ? 'relative' : 'absolute')};
-  border-radius: 2px;
+  border-radius: ${rem(0.2)};
   border: 0;
   box-sizing: border-box;
-  padding: 8px;
-  max-width: ${(props) => (props.type === 'relative' ? '100%' : '800px')};
+  padding: ${rem(0.8)};
+  max-width: ${(props) => (props.type === 'relative' ? '100%' : rem(80))};
   width: 100%;
   color: ${colors.shadeBlack};
   ${(props) => (props.type === 'banner' ? `top: 0px` : 'bottom: 0px')};

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -37,6 +37,7 @@ icons.CloseIcon
 icons.ExclamationIcon
 icons.FilterIcon
 icons.GiftCardIcon
+icons.InfoIcon
 icons.LogoutIcon
 icons.SubtractIcon
 ```
@@ -58,6 +59,7 @@ import ExclamationIcon from '@littlespoon/ui/icons/ExclamationIcon'
 import FilterIcon from '@littlespoon/ui/icons/FilterIcon'
 import GiftCardIcon from '@littlespoon/ui/icons/GiftCardIcon'
 import HamburgerMenuIcon from '@littlespoon/ui/icons/HamburgerMenuIcon'
+import InfoIcon from '@littlespoon/ui/icons/InfoIcon'
 import LogoutIcon from '@littlespoon/ui/icons/LogoutIcon'
 import SubtractIcon from '@littlespoon/ui/icons/SubtractIcon'
 ```

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -31,6 +31,7 @@ export {
   FilterIcon,
   GiftCardIcon,
   HamburgerMenuIcon,
+  InfoIcon,
   LogoutIcon,
   SubtractIcon,
 }

--- a/packages/storybook/src/stories/icons/InfoIcon.stories.tsx
+++ b/packages/storybook/src/stories/icons/InfoIcon.stories.tsx
@@ -1,0 +1,42 @@
+import InfoIcon from '@littlespoon/icons/src/InfoIcon'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+
+export default {
+  title: 'Design System/Icons/InfoIcon',
+  component: InfoIcon,
+} as ComponentMeta<typeof InfoIcon>
+
+const Template: ComponentStory<typeof InfoIcon> = (args) => <InfoIcon {...args} />
+
+export const Default = Template.bind({})
+Default.args = {}
+
+export const ExtraSmall = Template.bind({})
+ExtraSmall.args = {
+  size: 'xsmall',
+}
+
+export const Small = Template.bind({})
+Small.args = {
+  size: 'small',
+}
+
+export const Medium = Template.bind({})
+Medium.args = {
+  size: 'medium',
+}
+
+export const Large = Template.bind({})
+Large.args = {
+  size: 'large',
+}
+
+export const Fill = Template.bind({})
+Fill.args = {
+  fill: 'skyblue',
+}
+
+export const Stroke = Template.bind({})
+Stroke.args = {
+  stroke: 'tomato',
+}

--- a/packages/ui/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/ui/__tests__/__snapshots__/index.test.ts.snap
@@ -2,6 +2,32 @@
 
 exports[`exports ui 1`] = `
 {
+  "Accordion": {
+    "$$typeof": Symbol(react.forward_ref),
+    "attrs": [],
+    "componentStyle": e {
+      "baseHash": 84895702,
+      "baseStyle": undefined,
+      "componentId": "sc-cxabCf",
+      "isStatic": false,
+      "rules": [
+        "
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+",
+      ],
+      "staticRulesId": "",
+    },
+    "foldedComponentIds": [],
+    "render": [Function],
+    "shouldForwardProp": undefined,
+    "styledComponentId": "sc-cxabCf",
+    "target": "dl",
+    "toString": [Function],
+    "warnTooManyClasses": [Function],
+    "withComponent": [Function],
+  },
   "Alert": [Function],
   "Box": [Function],
   "Breadcrumb": [Function],

--- a/packages/ui/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/ui/__tests__/__snapshots__/index.test.ts.snap
@@ -2,32 +2,6 @@
 
 exports[`exports ui 1`] = `
 {
-  "Accordion": {
-    "$$typeof": Symbol(react.forward_ref),
-    "attrs": [],
-    "componentStyle": e {
-      "baseHash": 84895702,
-      "baseStyle": undefined,
-      "componentId": "sc-cxabCf",
-      "isStatic": false,
-      "rules": [
-        "
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-",
-      ],
-      "staticRulesId": "",
-    },
-    "foldedComponentIds": [],
-    "render": [Function],
-    "shouldForwardProp": undefined,
-    "styledComponentId": "sc-cxabCf",
-    "target": "dl",
-    "toString": [Function],
-    "warnTooManyClasses": [Function],
-    "withComponent": [Function],
-  },
   "Alert": [Function],
   "Box": [Function],
   "Breadcrumb": [Function],

--- a/packages/ui/icons/InfoIcon/index.ts
+++ b/packages/ui/icons/InfoIcon/index.ts
@@ -1,0 +1,2 @@
+export { default } from '@littlespoon/icons/lib/InfoIcon'
+export * from '@littlespoon/icons/lib/InfoIcon'


### PR DESCRIPTION
<!--
Filling out the information below can facilitate the review/merge of the pull request (PR)
All fields are optional
-->

## Jira

[LS-3944](https://littlespoon.atlassian.net/browse/LS-LS-3944)

## Motivation

Make the Alert full width when relative positioned in the PCH screens

## Current Behavior

![image](https://user-images.githubusercontent.com/24640314/190660677-e9003a39-6b8e-40ef-b493-6c628041d575.png)

The alert is not filling the space

## New Behavior

The relative positioned alert will fill the 100% width:

<img width="1915" alt="Screen Shot 2022-09-16 at 11 18 39" src="https://user-images.githubusercontent.com/24640314/190660840-49befebb-c4b3-4944-b3ba-0e564de4e9b9.png">

## Test Plan

- Open the StoryBook
- Check if the alert with type as relative occupy the full width
<img width="730" alt="Screen Shot 2022-09-16 at 11 19 17" src="https://user-images.githubusercontent.com/24640314/190660985-6d08d6c2-1889-4a64-9113-1247c561e112.png">
- Ensure that banner and toast types has 800px width to not break in other points.

## Affected Areas

Alert component

## Risk Analysis

<!--
What could go wrong?
What are you worried about?
What questions do you still have?
-->

## Non-Function Requirements

<!-- Performance, impact, dependencies, etc. -->

## Linked Issues

<!-- Related tickets or PRs -->

## Screenshot

<!-- For user facing changes -->

## Checklist

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [ ] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation
- [ ] Storybook

<!--
Any other comments? Thanks for contributing!
-->
