### PR TITLE
feat: add drawer animations PCH-352

### DIFF
--- a/packages/drawer/__tests__/Backdrop.test.tsx
+++ b/packages/drawer/__tests__/Backdrop.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { axe } from 'jest-axe'
 
 import Backdrop from '../src/Backdrop'
+import { ANIMATION_DURATION } from '../src/Drawer'
 
 const backdropTestId = 'backdrop'
 
@@ -40,12 +41,14 @@ describe('with props.open', () => {
 })
 
 describe('with props.onClick', () => {
-  it('fires the onClick event', () => {
+  it('fires the onClick event', async () => {
     const handleClick = jest.fn()
     render(<Backdrop onClick={handleClick} open />)
     const backdrop = screen.getByTestId(backdropTestId)
     expect(backdrop).toBeInTheDocument()
     fireEvent.click(backdrop)
+    // Make sure the animation is finished
+    await new Promise((r) => setTimeout(r, ANIMATION_DURATION * 2))
     expect(handleClick).toHaveBeenCalledTimes(1)
     expect(backdrop).not.toBeInTheDocument()
   })

--- a/packages/drawer/__tests__/Backdrop.test.tsx
+++ b/packages/drawer/__tests__/Backdrop.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { axe } from 'jest-axe'
 
 import Backdrop from '../src/Backdrop'
-import { ANIMATION_DURATION } from '../src/Drawer'
+import { SHOW_HIDE_ANIMATION_DURATION } from '../src/Drawer'
 
 const backdropTestId = 'backdrop'
 
@@ -48,7 +48,7 @@ describe('with props.onClick', () => {
     expect(backdrop).toBeInTheDocument()
     fireEvent.click(backdrop)
     // Make sure the animation is finished
-    await new Promise((r) => setTimeout(r, ANIMATION_DURATION * 2))
+    await new Promise((r) => setTimeout(r, SHOW_HIDE_ANIMATION_DURATION * 2))
     expect(handleClick).toHaveBeenCalledTimes(1)
     expect(backdrop).not.toBeInTheDocument()
   })

--- a/packages/drawer/__tests__/Drawer.test.tsx
+++ b/packages/drawer/__tests__/Drawer.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { axe } from 'jest-axe'
 import styled from 'styled-components'
 
-import Drawer, { ANIMATION_DURATION } from '../src/'
+import Drawer, { SHOW_HIDE_ANIMATION_DURATION } from '../src/'
 
 const backdropTestId = 'backdrop'
 const closeButtonTitle = 'Close'
@@ -98,7 +98,7 @@ describe('with props.disableBackdropClick', () => {
     expect(drawer).toBeInTheDocument()
     fireEvent.click(backdrop)
     // Make sure the animation is finished
-    await new Promise((r) => setTimeout(r, ANIMATION_DURATION * 2))
+    await new Promise((r) => setTimeout(r, SHOW_HIDE_ANIMATION_DURATION * 2))
     expect(handleClose).toHaveBeenCalledTimes(1)
     expect(backdrop).not.toBeInTheDocument()
     expect(drawer).not.toBeInTheDocument()
@@ -128,7 +128,7 @@ describe('with props.disableEscapeKeyDown', () => {
     expect(drawer).toBeInTheDocument()
     fireEvent.keyDown(drawer, keyDownEventProperties)
     // Make sure the animation is finished
-    await new Promise((r) => setTimeout(r, ANIMATION_DURATION * 2))
+    await new Promise((r) => setTimeout(r, SHOW_HIDE_ANIMATION_DURATION * 2))
     expect(handleClose).toHaveBeenCalledTimes(1)
     expect(drawer).not.toBeInTheDocument()
   })
@@ -174,7 +174,7 @@ describe('with props.onClose', () => {
     expect(closeButton).toBeInTheDocument()
     fireEvent.click(closeButton)
     // Make sure the animation is finished
-    await new Promise((r) => setTimeout(r, ANIMATION_DURATION * 2))
+    await new Promise((r) => setTimeout(r, SHOW_HIDE_ANIMATION_DURATION * 2))
     expect(handleClose).toHaveBeenCalledTimes(1)
     expect(drawer).not.toBeInTheDocument()
     expect(closeButton).not.toBeInTheDocument()

--- a/packages/drawer/__tests__/Drawer.test.tsx
+++ b/packages/drawer/__tests__/Drawer.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { axe } from 'jest-axe'
 import styled from 'styled-components'
 
-import Drawer from '../src/'
+import Drawer, { ANIMATION_DURATION } from '../src/'
 
 const backdropTestId = 'backdrop'
 const closeButtonTitle = 'Close'
@@ -89,7 +89,7 @@ describe('with props.className', () => {
 })
 
 describe('with props.disableBackdropClick', () => {
-  it('fires the onClose event', () => {
+  it('fires the onClose event', async () => {
     const handleClose = jest.fn()
     render(<Drawer disableBackdropClick={false} onClose={handleClose} open />)
     const backdrop = screen.getByTestId(backdropTestId)
@@ -97,6 +97,8 @@ describe('with props.disableBackdropClick', () => {
     expect(backdrop).toBeInTheDocument()
     expect(drawer).toBeInTheDocument()
     fireEvent.click(backdrop)
+    // Make sure the animation is finished
+    await new Promise((r) => setTimeout(r, ANIMATION_DURATION * 2))
     expect(handleClose).toHaveBeenCalledTimes(1)
     expect(backdrop).not.toBeInTheDocument()
     expect(drawer).not.toBeInTheDocument()
@@ -119,12 +121,14 @@ describe('with props.disableBackdropClick', () => {
 describe('with props.disableEscapeKeyDown', () => {
   const keyDownEventProperties = { charCode: 27, code: 'Escape', key: 'Escape' }
 
-  it('fires the onClose event', () => {
+  it('fires the onClose event', async () => {
     const handleClose = jest.fn()
     render(<Drawer disableEscapeKeyDown={false} onClose={handleClose} open />)
     const drawer = screen.getByRole(drawerRole)
     expect(drawer).toBeInTheDocument()
     fireEvent.keyDown(drawer, keyDownEventProperties)
+    // Make sure the animation is finished
+    await new Promise((r) => setTimeout(r, ANIMATION_DURATION * 2))
     expect(handleClose).toHaveBeenCalledTimes(1)
     expect(drawer).not.toBeInTheDocument()
   })
@@ -161,7 +165,7 @@ describe('with props.closeButtonTitle', () => {
 })
 
 describe('with props.onClose', () => {
-  it('fires the onClose event', () => {
+  it('fires the onClose event', async () => {
     const handleClose = jest.fn()
     render(<Drawer onClose={handleClose} open showCloseButton />)
     const drawer = screen.getByRole(drawerRole)
@@ -169,6 +173,8 @@ describe('with props.onClose', () => {
     expect(drawer).toBeInTheDocument()
     expect(closeButton).toBeInTheDocument()
     fireEvent.click(closeButton)
+    // Make sure the animation is finished
+    await new Promise((r) => setTimeout(r, ANIMATION_DURATION * 2))
     expect(handleClose).toHaveBeenCalledTimes(1)
     expect(drawer).not.toBeInTheDocument()
     expect(closeButton).not.toBeInTheDocument()

--- a/packages/drawer/src/Backdrop.tsx
+++ b/packages/drawer/src/Backdrop.tsx
@@ -17,11 +17,12 @@ export type BackdropProps = PropsWithChildren<{
 
   /**
    * Opacity
+   * @defaultValue `1`
    */
-  opacity: number
+  opacity?: number
 }>
 
-export default function Backdrop({ children, onClick, open = false, opacity }: BackdropProps) {
+export default function Backdrop({ children, onClick, open = false, opacity = 1 }: BackdropProps) {
   const [isOpen, setIsOpen] = useState(false)
 
   useEffect(() => {

--- a/packages/drawer/src/Backdrop.tsx
+++ b/packages/drawer/src/Backdrop.tsx
@@ -1,7 +1,7 @@
 import { PropsWithChildren, useEffect, useState } from 'react'
 
 import { BackdropBase } from './BackdropBase'
-import { ANIMATION_DURATION } from './Drawer'
+import { SHOW_HIDE_ANIMATION_DURATION } from './Drawer'
 
 export type BackdropProps = PropsWithChildren<{
   /**
@@ -36,7 +36,7 @@ export default function Backdrop({ children, onClick, open = false, opacity = 1 
     onClick()
     setTimeout(() => {
       setIsOpen(false)
-    }, ANIMATION_DURATION)
+    }, SHOW_HIDE_ANIMATION_DURATION)
   }
 
   if (!isOpen) {

--- a/packages/drawer/src/Backdrop.tsx
+++ b/packages/drawer/src/Backdrop.tsx
@@ -1,6 +1,7 @@
 import { PropsWithChildren, useEffect, useState } from 'react'
 
 import { BackdropBase } from './BackdropBase'
+import { ANIMATION_DURATION } from './Drawer'
 
 export type BackdropProps = PropsWithChildren<{
   /**
@@ -13,9 +14,14 @@ export type BackdropProps = PropsWithChildren<{
    * @defaultValue `false`
    */
   open?: boolean
+
+  /**
+   * Opacity
+   */
+  opacity: number
 }>
 
-export default function Backdrop({ children, onClick, open = false }: BackdropProps) {
+export default function Backdrop({ children, onClick, open = false, opacity }: BackdropProps) {
   const [isOpen, setIsOpen] = useState(false)
 
   useEffect(() => {
@@ -26,8 +32,10 @@ export default function Backdrop({ children, onClick, open = false }: BackdropPr
     if (!onClick) {
       return
     }
-    setIsOpen(false)
     onClick()
+    setTimeout(() => {
+      setIsOpen(false)
+    }, ANIMATION_DURATION)
   }
 
   if (!isOpen) {
@@ -35,7 +43,7 @@ export default function Backdrop({ children, onClick, open = false }: BackdropPr
   }
 
   return (
-    <BackdropBase aria-hidden data-testid="backdrop" onClick={handleClick}>
+    <BackdropBase opacity={opacity} aria-hidden data-testid="backdrop" onClick={handleClick}>
       {children}
     </BackdropBase>
   )

--- a/packages/drawer/src/BackdropBase.tsx
+++ b/packages/drawer/src/BackdropBase.tsx
@@ -1,17 +1,23 @@
 import { surfaceOverlay60 } from '@littlespoon/theme/lib/colors/token'
 import zIndex from '@littlespoon/theme/lib/z-index'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
-export const BackdropBase = styled.div`
-  align-items: center;
-  background-color: ${surfaceOverlay60};
-  bottom: 0;
-  display: flex;
-  justify-content: center;
-  left: 0;
-  position: fixed;
-  right: 0;
-  top: 0;
-  z-index: ${zIndex.backdrop};
-  -webkit-tap-highlight-color: transparent;
-`
+import { ANIMATION_DURATION } from './Drawer'
+
+export const BackdropBase = styled.div<{ opacity: number }>(
+  (props) => css`
+    align-items: center;
+    background-color: ${surfaceOverlay60};
+    bottom: 0;
+    display: flex;
+    justify-content: center;
+    left: 0;
+    position: fixed;
+    right: 0;
+    top: 0;
+    z-index: ${zIndex.backdrop};
+    -webkit-tap-highlight-color: transparent;
+    transition: opacity ${ANIMATION_DURATION}ms ease-in-out;
+    opacity: ${props.opacity};
+  `,
+)

--- a/packages/drawer/src/BackdropBase.tsx
+++ b/packages/drawer/src/BackdropBase.tsx
@@ -2,7 +2,7 @@ import { surfaceOverlay60 } from '@littlespoon/theme/lib/colors/token'
 import zIndex from '@littlespoon/theme/lib/z-index'
 import styled, { css } from 'styled-components'
 
-import { ANIMATION_DURATION } from './Drawer'
+import { SHOW_HIDE_ANIMATION_DURATION } from './Drawer'
 
 export const BackdropBase = styled.div<{ opacity: number }>(
   (props) => css`
@@ -17,7 +17,7 @@ export const BackdropBase = styled.div<{ opacity: number }>(
     top: 0;
     z-index: ${zIndex.backdrop};
     -webkit-tap-highlight-color: transparent;
-    transition: opacity ${ANIMATION_DURATION}ms ease-in-out;
+    transition: opacity ${SHOW_HIDE_ANIMATION_DURATION}ms ease-in-out;
     opacity: ${props.opacity};
   `,
 )

--- a/packages/drawer/src/Drawer.tsx
+++ b/packages/drawer/src/Drawer.tsx
@@ -59,7 +59,8 @@ export type DrawerProps = PropsWithChildren<{
   showCloseButton?: boolean
 }>
 
-export const ANIMATION_DURATION = 300
+// Show/Hide animation duration in milliseconds
+export const SHOW_HIDE_ANIMATION_DURATION = 300
 
 export default function Drawer({
   'aria-label': ariaLabel,
@@ -72,24 +73,28 @@ export default function Drawer({
   open = false,
   showCloseButton = false,
 }: DrawerProps) {
-  const drawerHiddenStateMargin = -1000
+  const initialBackdropOpacity = 0
+  const initialDrawerMargin = -1000
+  const finalBackdropOpacity = 1
+  const finalDrawerMargin = 0
+
   const [isOpen, setIsOpen] = useState(false)
-  const [drawerHiddenMargin, setDrawerHiddenMargin] = useState(drawerHiddenStateMargin)
-  const [backdropOpacity, setBackdropOpacity] = useState(0)
+  const [drawerMargin, setDrawerMargin] = useState(initialDrawerMargin)
+  const [backdropOpacity, setBackdropOpacity] = useState(initialBackdropOpacity)
 
   const playShowDrawerAnimation = () => {
     // We want to execute it after the rerender
     setTimeout(() => {
-      setDrawerHiddenMargin(0)
-      setBackdropOpacity(1)
+      setDrawerMargin(finalDrawerMargin)
+      setBackdropOpacity(finalBackdropOpacity)
     }, 1)
   }
 
   const playHideDrawerAnimation = () => {
     // We want to execute it after the rerender
     setTimeout(() => {
-      setBackdropOpacity(0)
-      setDrawerHiddenMargin(drawerHiddenStateMargin)
+      setBackdropOpacity(initialBackdropOpacity)
+      setDrawerMargin(initialDrawerMargin)
     }, 1)
   }
 
@@ -118,7 +123,7 @@ export default function Drawer({
     setTimeout(() => {
       setIsOpen(false)
       onClose()
-    }, ANIMATION_DURATION)
+    }, SHOW_HIDE_ANIMATION_DURATION)
   }
 
   const onEscapeKey = disableEscapeKeyDown ? undefined : handleClose
@@ -129,7 +134,7 @@ export default function Drawer({
       <FocusOn onEscapeKey={onEscapeKey}>
         <Backdrop onClick={onBackdropClick} open={isOpen} opacity={backdropOpacity} />
         <DrawerBase
-          hiddenMargin={drawerHiddenMargin}
+          hiddenMargin={drawerMargin}
           aria-label={ariaLabel}
           aria-modal
           className={className}

--- a/packages/drawer/src/Drawer.tsx
+++ b/packages/drawer/src/Drawer.tsx
@@ -59,6 +59,8 @@ export type DrawerProps = PropsWithChildren<{
   showCloseButton?: boolean
 }>
 
+export const ANIMATION_DURATION = 300
+
 export default function Drawer({
   'aria-label': ariaLabel,
   children,
@@ -70,11 +72,38 @@ export default function Drawer({
   open = false,
   showCloseButton = false,
 }: DrawerProps) {
+  const drawerHiddenStateMargin = -1000
   const [isOpen, setIsOpen] = useState(false)
+  const [drawerHiddenMargin, setDrawerHiddenMargin] = useState(drawerHiddenStateMargin)
+  const [backdropOpacity, setBackdropOpacity] = useState(0)
+
+  const playShowDrawerAnimation = () => {
+    // We want to execute it after the rerender
+    setTimeout(() => {
+      setDrawerHiddenMargin(0)
+      setBackdropOpacity(1)
+    }, 1)
+  }
+
+  const playHideDrawerAnimation = () => {
+    // We want to execute it after the rerender
+    setTimeout(() => {
+      setBackdropOpacity(0)
+      setDrawerHiddenMargin(drawerHiddenStateMargin)
+    }, 1)
+  }
 
   useEffect(() => {
     setIsOpen(open)
   }, [open])
+
+  useEffect(() => {
+    if (isOpen) {
+      playShowDrawerAnimation()
+    } else {
+      playHideDrawerAnimation()
+    }
+  }, [isOpen])
 
   if (!isOpen) {
     return null
@@ -84,8 +113,12 @@ export default function Drawer({
     if (!onClose) {
       return
     }
-    setIsOpen(false)
-    onClose()
+
+    playHideDrawerAnimation()
+    setTimeout(() => {
+      setIsOpen(false)
+      onClose()
+    }, ANIMATION_DURATION)
   }
 
   const onEscapeKey = disableEscapeKeyDown ? undefined : handleClose
@@ -94,8 +127,14 @@ export default function Drawer({
   return (
     <Portal>
       <FocusOn onEscapeKey={onEscapeKey}>
-        <Backdrop onClick={onBackdropClick} open={isOpen} />
-        <DrawerBase aria-label={ariaLabel} aria-modal className={className} role="dialog">
+        <Backdrop onClick={onBackdropClick} open={isOpen} opacity={backdropOpacity} />
+        <DrawerBase
+          hiddenMargin={drawerHiddenMargin}
+          aria-label={ariaLabel}
+          aria-modal
+          className={className}
+          role="dialog"
+        >
           {showCloseButton && (
             <DrawerCloseButtonContainer>
               <DrawerCloseButton

--- a/packages/drawer/src/DrawerBase.tsx
+++ b/packages/drawer/src/DrawerBase.tsx
@@ -5,7 +5,7 @@ import { rem } from '@littlespoon/theme/lib/utils'
 import zIndex from '@littlespoon/theme/lib/z-index'
 import styled, { css } from 'styled-components'
 
-import { ANIMATION_DURATION, DrawerProps } from './Drawer'
+import { DrawerProps, SHOW_HIDE_ANIMATION_DURATION } from './Drawer'
 
 export const DrawerBase = styled.div<Partial<DrawerProps> & { hiddenMargin: number }>(
   (props) => css`
@@ -29,7 +29,7 @@ export const DrawerBase = styled.div<Partial<DrawerProps> & { hiddenMargin: numb
     right: 0;
     z-index: ${zIndex.drawer};
     margin-bottom: ${props.hiddenMargin}px;
-    transition: margin-bottom ${ANIMATION_DURATION}ms ease-in-out;
+    transition: margin-bottom ${SHOW_HIDE_ANIMATION_DURATION}ms ease-in-out;
 
     ${up(
       md,
@@ -44,7 +44,7 @@ export const DrawerBase = styled.div<Partial<DrawerProps> & { hiddenMargin: numb
         width: ${rem(48)};
         margin-bottom: 0;
         margin-right: ${props.hiddenMargin}px;
-        transition: margin-right ${ANIMATION_DURATION}ms ease-in-out;
+        transition: margin-right ${SHOW_HIDE_ANIMATION_DURATION}ms ease-in-out;
     `,
     )}
   `,

--- a/packages/drawer/src/DrawerBase.tsx
+++ b/packages/drawer/src/DrawerBase.tsx
@@ -3,45 +3,52 @@ import { md, up } from '@littlespoon/theme/lib/breakpoints'
 import { shadeWhite } from '@littlespoon/theme/lib/colors/token'
 import { rem } from '@littlespoon/theme/lib/utils'
 import zIndex from '@littlespoon/theme/lib/z-index'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
-import { DrawerProps } from './Drawer'
+import { ANIMATION_DURATION, DrawerProps } from './Drawer'
 
-export const DrawerBase = styled.div<Partial<DrawerProps>>`
-  align-content: stretch;
-  background-color: ${shadeWhite};
-  border: 0;
-  border-radius: ${rem(1.2)} ${rem(1.2)} 0 0;
-  bottom: 0;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  gap: ${rem(1.6)};
-  left: 0;
-  margin: 0;
-  max-height: 80%;
-  max-width: none;
-  outline: none;
-  overflow: hidden;
-  padding: ${rem(2)};
-  position: fixed;
-  right: 0;
-  z-index: ${zIndex.drawer};
+export const DrawerBase = styled.div<Partial<DrawerProps> & { hiddenMargin: number }>(
+  (props) => css`
+    align-content: stretch;
+    background-color: ${shadeWhite};
+    border: 0;
+    border-radius: ${rem(1.2)} ${rem(1.2)} 0 0;
+    bottom: 0;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    gap: ${rem(1.6)};
+    left: 0;
+    margin: 0;
+    max-height: 80%;
+    max-width: none;
+    outline: none;
+    overflow: hidden;
+    padding: ${rem(2)};
+    position: fixed;
+    right: 0;
+    z-index: ${zIndex.drawer};
+    margin-bottom: ${props.hiddenMargin}px;
+    transition: margin-bottom ${ANIMATION_DURATION}ms ease-in-out;
 
-  ${up(
-    md,
-    `
-    border-radius: 0;
-    justify-content: flex-end;
-    left: auto;
-    max-height: none;
-    max-width: ${rem(48)};
-    padding: ${rem(4)};
-    top: 0;
-    width: ${rem(48)};
+    ${up(
+      md,
+      `
+        border-radius: 0;
+        justify-content: flex-end;
+        left: auto;
+        max-height: none;
+        max-width: ${rem(48)};
+        padding: ${rem(4)};
+        top: 0;
+        width: ${rem(48)};
+        margin-bottom: 0;
+        margin-right: ${props.hiddenMargin}px;
+        transition: margin-right ${ANIMATION_DURATION}ms ease-in-out;
     `,
-  )}
-`
+    )}
+  `,
+)
 
 export const DrawerCloseButtonContainer = styled.div`
   display: flex;


### PR DESCRIPTION
## Jira

[DS: Add animations to the drawer](https://littlespoon.atlassian.net/browse/PCH-352)

## Motivation

Make user flow smoother

## Current Behavior

The drawer and backdrop just blinks into the view

## New Behavior

The drawer slides from the right (or from the bottom for mobile) and the backdrop fades in and out

## Test Plan

Review app: https://deploy-preview-766--littlespoon.netlify.app/
Manual QA
Desk check

## Affected Areas

Drawer

## Risk Analysis

Low risk

## Screenshot

https://user-images.githubusercontent.com/58109902/210412694-9f8127cf-9255-440a-89b4-3fdef162c094.mov




[PCH-352]: https://littlespoon.atlassian.net/browse/PCH-352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ