### PR TITLE
refactor(accordion): fix older iOS ResizeObserver compatibility issue PCH-501

### DIFF
--- a/packages/accordion/src/AccordionDetails.tsx
+++ b/packages/accordion/src/AccordionDetails.tsx
@@ -19,18 +19,24 @@ export function AccordionDetails({
 
   /* istanbul ignore next */
   useEffect(() => {
-    // create the observer only once
-    resizeObserver.current = new ResizeObserver(() => {
-      if (contentRef.current) {
-        setInnerContentHeight(contentRef.current.scrollHeight)
-      }
-    })
+    if (typeof ResizeObserver !== 'undefined') {
+      // create the observer only once
+      resizeObserver.current = new ResizeObserver(() => {
+        if (contentRef.current) {
+          setInnerContentHeight(contentRef.current.scrollHeight)
+        }
+      })
 
-    if (contentRef.current) {
-      resizeObserver.current.observe(contentRef.current)
-    }
-    return () => {
-      resizeObserver.current?.disconnect()
+      if (contentRef.current) {
+        resizeObserver.current.observe(contentRef.current)
+      }
+      return () => {
+        resizeObserver.current?.disconnect()
+      }
+    } else {
+      if (contentRef?.current?.scrollHeight) {
+        setInnerContentHeight(contentRef?.current?.scrollHeight)
+      }
     }
   }, [])
 

--- a/packages/accordion/src/AccordionDetails.tsx
+++ b/packages/accordion/src/AccordionDetails.tsx
@@ -19,6 +19,7 @@ export function AccordionDetails({
 
   /* istanbul ignore next */
   useEffect(() => {
+    // for OS that lack ResizeObserver support use fallback when undefined
     if (typeof ResizeObserver !== 'undefined') {
       // create the observer only once
       resizeObserver.current = new ResizeObserver(() => {

--- a/packages/accordion/src/AccordionDetails.tsx
+++ b/packages/accordion/src/AccordionDetails.tsx
@@ -20,7 +20,7 @@ export function AccordionDetails({
   /* istanbul ignore next */
   useEffect(() => {
     // for OS that lack ResizeObserver support use fallback when undefined
-    if (typeof ResizeObserver !== 'undefined') {
+    if ('ResizeObserver' in window) {
       // create the observer only once
       resizeObserver.current = new ResizeObserver(() => {
         if (contentRef.current) {


### PR DESCRIPTION
<!--
Filling out the information below can facilitate the review/merge of the pull request (PR)
All fields are optional
-->

## Jira

[DS: Fix AccordionDetails for Old iOS Versions](https://littlespoon.atlassian.net/browse/PCH-501)

## Test Plan
- Should throw an error when visiting [current accordion storybook](https://littlespoon.netlify.app/?path=/story/design-system-accordion--multiple) with iOS 13.3 or lower
- Should load when visiting [PR's accordion storybook](https://deploy-preview-817--littlespoon.netlify.app/?path=/story/design-system-accordion--multiple) with iOS 13.3 or lower

## Checklist

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Storybook

<!--
Any other comments? Thanks for contributing!
-->
