### PR TITLE
feat(button): add size by breakpoint support for button WEB-1332

### DIFF
--- a/packages/button/__tests__/Button.test.tsx
+++ b/packages/button/__tests__/Button.test.tsx
@@ -162,3 +162,25 @@ describe('with props.as', () => {
     expect(screen.getByText(children)).toBeInTheDocument()
   })
 })
+
+describe('with props.size as object', () => {
+  it('have proper styles for size with breakpoints', () => {
+    const text = 'Size by breakpoint test desktop'
+    render(
+      <Button
+        size={{
+          0: 'small',
+          1500: 'medium',
+        }}
+      >
+        {text}
+      </Button>,
+    )
+
+    expect(document.querySelectorAll('button').length).toBe(1)
+    expect(screen.getByText(text)).toHaveStyle({
+      height: '4rem',
+      padding: '0.8rem 1.8rem',
+    })
+  })
+})

--- a/packages/button/__tests__/Button.test.tsx
+++ b/packages/button/__tests__/Button.test.tsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom'
 import { render, screen } from '@testing-library/react'
 import { axe } from 'jest-axe'
 
-import type { ButtonProps } from '../src/'
+import type { ButtonProps, Size } from '../src/'
 import Button from '../src/'
 
 const children = 'children'
@@ -78,7 +78,7 @@ describe('with props.size', () => {
     'renders button with size=%j',
     (size) => {
       render(<Button size={size}>{size}</Button>)
-      expect(screen.getByText(size)).toBeInTheDocument()
+      expect(screen.getByText(size as Size)).toBeInTheDocument()
     },
   )
 })
@@ -170,7 +170,7 @@ describe('with props.size as object', () => {
       <Button
         size={{
           0: 'small',
-          1500: 'medium',
+          1500: 'large',
         }}
       >
         {text}
@@ -179,8 +179,8 @@ describe('with props.size as object', () => {
 
     expect(document.querySelectorAll('button').length).toBe(1)
     expect(screen.getByText(text)).toHaveStyle({
-      height: '4rem',
-      padding: '0.8rem 1.8rem',
+      height: '3.2rem',
+      padding: '0.6rem 1.6rem',
     })
   })
 })

--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -2,6 +2,12 @@ import type React from 'react'
 
 import { ButtonBase } from './ButtonBase'
 
+export type Size = 'small' | 'medium' | 'large' | 'xlarge'
+
+export interface SizeByBreakpoint {
+  [key: number]: Size
+}
+
 export interface Props<C extends React.ElementType> {
   /**
    * The root node component. Use a string for an HTML element or a component. Defaults to "button".
@@ -16,7 +22,7 @@ export interface Props<C extends React.ElementType> {
   /**
    * The size of the component. Defaults to "medium".
    */
-  size?: 'small' | 'medium' | 'large' | 'xlarge'
+  size?: Size | SizeByBreakpoint
 
   /**
    * The variant to use. Defaults to "primary".

--- a/packages/button/src/ButtonBase.tsx
+++ b/packages/button/src/ButtonBase.tsx
@@ -6,7 +6,7 @@ import { button, family, weight } from '@littlespoon/theme/lib/fonts/primary'
 import { rem } from '@littlespoon/theme/lib/utils'
 import styled from 'styled-components'
 
-import type { ButtonProps } from './Button'
+import type { ButtonProps, Size } from './Button'
 
 export const ButtonBase = styled.button<ButtonProps<'button'>>`
   align-items: center;
@@ -20,15 +20,42 @@ export const ButtonBase = styled.button<ButtonProps<'button'>>`
   text-decoration: none;
   text-transform: uppercase;
   width: fit-content;
-  ${getSizeCss}
-  ${getVariantCss}
+  ${getCss}
 `
+
+/**
+ * Returns the CSS for the button.
+ */
+function getCss(options: ButtonProps<'button'>): string {
+  if (typeof options.size === 'object') {
+    const breakpoints = Object.entries(options.size)
+    return breakpoints.reduce((css, [breakpoint, size]) => {
+      if (+breakpoint === 0) {
+        css += getSizeCss({ ...options, size })
+        css += getVariantCss({ ...options, size })
+      } else {
+        css += `
+          @media screen and (min-width: ${breakpoint}px) {
+            ${getSizeCss({ ...options, size })} 
+            ${getVariantCss({ ...options, size })} 
+          }
+        `
+      }
+      return css
+    }, '')
+  }
+
+  return `
+    ${getSizeCss(options)}
+    ${getVariantCss(options)}
+  `
+}
 
 /**
  * Gets size styles.
  */
 function getSizeCss(props: ButtonProps<'button'>): string {
-  const { size } = props
+  const size = props.size as Size
   if (!size) {
     return ''
   }

--- a/packages/storybook/src/stories/Button.stories.tsx
+++ b/packages/storybook/src/stories/Button.stories.tsx
@@ -1,6 +1,8 @@
 import Button from '@littlespoon/button/src/Button'
 import { ComponentMeta, ComponentStory } from '@storybook/react'
 
+import { STORYBOOK_BREAKPOINT } from '../constants'
+
 export default {
   title: 'Design System/Button',
   component: Button,
@@ -80,5 +82,15 @@ Click.args = {
   onClick: () => {
     console.log('Clicked!') // eslint-disable-line no-console
     alert('Clicked!')
+  },
+}
+
+export const SizeByBreakpoint = Template.bind({})
+SizeByBreakpoint.args = {
+  children: 'Size by breakpoint',
+  size: {
+    0: 'small',
+    [STORYBOOK_BREAKPOINT.LARGE_MOBILE]: 'medium',
+    [STORYBOOK_BREAKPOINT.TABLET]: 'large',
   },
 }


### PR DESCRIPTION
## Jira

[[DS] Update button component to support media queries](https://littlespoon.atlassian.net/browse/WEB-1332)

## Motivation

New feature for button

## Current Behavior

Button doesn't support size by breakpoint

## New Behavior

Button supports size by breakpoint

## Test Plan

Manual QA

## Affected Areas

Button size prop

## Risk Analysis

Low risk
